### PR TITLE
 add an enviroment option to  disable user self registration

### DIFF
--- a/apps/nestjs-backend/src/features/auth/auth.controller.ts
+++ b/apps/nestjs-backend/src/features/auth/auth.controller.ts
@@ -34,6 +34,9 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
     @Req() req: Express.Request
   ) {
+if (process.env.DISABLE_SIGNUP === 'true') {
+    throw new ForbiddenException('Sign-up is disabled.');
+  }  
     const user = pickUserMe(await this.authService.signup(body.email, body.password));
     // set cookie, passport login
     await new Promise<void>((resolve, reject) => {

--- a/apps/nextjs-app/.env.example
+++ b/apps/nextjs-app/.env.example
@@ -88,3 +88,8 @@ BACKEND_GITHUB_CLIENT_ID=github_client_id
 BACKEND_GITHUB_CLIENT_SECRET=github_client_secret
 # separated by ','
 SOCIAL_AUTH_PROVIDERS=github,google
+
+
+#########
+### This should be activated after the admin first sign up , to allow the Owner/admin to prevent user from sgin up. 
+DISABLE_SIGNUP=true

--- a/apps/nextjs-app/.env.example
+++ b/apps/nextjs-app/.env.example
@@ -91,5 +91,5 @@ SOCIAL_AUTH_PROVIDERS=github,google
 
 
 #########
-### This should be activated after the admin first sign up , to allow the Owner/admin to prevent user from sgin up. 
+### This should be activated after the admin first sign up , to allow the Owner/admin to prevent user from sgin up. the default is false 
 DISABLE_SIGNUP=true


### PR DESCRIPTION
This will add environment option to disable user self registration , this is a simple method that can be triggered after the first run of the application and the owner or admin register him self and then can make sure that only user with valid invitation link is able to sign in , or he can provide another instance that has the user registration allowed.