### PR TITLE
docs: add deploy on Zeabur in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 1. Looking for a quick experience? Select a scenario from the [template center](https://template.teable.io) and click "Use this template".
 2. Seeking high performance? Try the [1 million rows demo](https://app.teable.io/share/shrVgdLiOvNQABtW0yX/view) to feel the speed of Teable.
 3. Want to learn to use it quickly? Click on this [tutorial](https://help.teable.io/quick-start/build-a-simple-base)
-4. Interested in deploying it yourself? Click [Deploy on Railway](https://railway.app/template/wada5e?referralCode=rE4BjB) or [Deploy on Zeabur](https://zeabur.com/templates/QF8695)
+4. Interested in deploying it yourself? Click [Deploy on Railway](https://railway.app/template/wada5e?referralCode=rE4BjB)
 
 ## ✨Features
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 1. Looking for a quick experience? Select a scenario from the [template center](https://template.teable.io) and click "Use this template".
 2. Seeking high performance? Try the [1 million rows demo](https://app.teable.io/share/shrVgdLiOvNQABtW0yX/view) to feel the speed of Teable.
 3. Want to learn to use it quickly? Click on this [tutorial](https://help.teable.io/quick-start/build-a-simple-base)
-4. Interested in deploying it yourself? Click [Deploy on Railway](https://railway.app/template/wada5e?referralCode=rE4BjB)
+4. Interested in deploying it yourself? Click [Deploy on Railway](https://railway.app/template/wada5e?referralCode=rE4BjB) or [Deploy on Zeabur](https://zeabur.com/templates/QF8695)
 
 ## ✨Features
 
@@ -179,6 +179,10 @@ for more details, see [dockers/examples](dockers/examples)
 ### Deploy with Railway
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/wada5e?referralCode=rE4BjB)
+
+### Deploy with Zeabur
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/QF8695)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ docker-compose up -d
 
 for more details, see [dockers/examples](dockers/examples)
 
-### Deploy with Railway
+### One Click Deployment
+
+These platforms are easy to deploy with one click and come with free credits.
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/wada5e?referralCode=rE4BjB)
-
-### Deploy with Zeabur
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/QF8695)
 


### PR DESCRIPTION
Add Zeabur as another self host option.
[Template preview](https://zeabur.com/templates/QF8695): 
<img width="1512" alt="image" src="https://github.com/teableio/teable/assets/63531512/8b43fe06-a40b-41bc-aa42-33372dbe7d98">
Deployed project:
<img width="1512" alt="image" src="https://github.com/teableio/teable/assets/63531512/e2c3382e-8c64-4410-b0a4-d9c4762575c4">
