### PR TITLE
fix: allow default db address

### DIFF
--- a/apps/nestjs-backend/src/configs/base.config.ts
+++ b/apps/nestjs-backend/src/configs/base.config.ts
@@ -9,7 +9,7 @@ export const baseConfig = registerAs('base', () => ({
   assetPrefix: process.env.ASSET_PREFIX ?? process.env.PUBLIC_ORIGIN!,
   storagePrefix: process.env.STORAGE_PREFIX ?? process.env.PUBLIC_ORIGIN!,
   secretKey: process.env.SECRET_KEY ?? 'defaultSecretKey',
-  publicDatabaseAddress: process.env.PUBLIC_DATABASE_ADDRESS,
+  publicDatabaseAddress: process.env.PUBLIC_DATABASE_ADDRESS ?? process.env.PRISMA_DATABASE_URL,
   defaultMaxBaseDBConnections: Number(process.env.DEFAULT_MAX_BASE_DB_CONNECTIONS ?? 3),
   templateSpaceId: process.env.TEMPLATE_SPACE_ID,
 }));


### PR DESCRIPTION
The default address should be used to create the database connection
