### PR TITLE
chore: adjusting cookie expiration time for login session

### DIFF
--- a/apps/nestjs-backend/src/features/auth/session/session-handle.service.ts
+++ b/apps/nestjs-backend/src/features/auth/session/session-handle.service.ts
@@ -19,7 +19,7 @@ export class SessionHandleService {
       resave: false,
       saveUninitialized: false,
       cookie: {
-        maxAge: ms(this.authConfig.session.expiresIn),
+        maxAge: ms('1y'),
       },
       store: this.sessionStoreService,
     });


### PR DESCRIPTION
Extend the expiration time of the login session cookie to avoid the cookie expiring too quickly.