### PR TITLE
fix: field list order may random

### DIFF
--- a/apps/nestjs-backend/src/features/field/field.service.ts
+++ b/apps/nestjs-backend/src/features/field/field.service.ts
@@ -78,6 +78,13 @@ export class FieldService implements IReadonlyAdapterService {
       isLookup,
     } = fieldInstance;
 
+    const agg = await this.prismaService.txClient().field.aggregate({
+      where: { tableId, deletedTime: null },
+      _max: {
+        order: true,
+      },
+    });
+    const order = agg._max.order == null ? 0 : agg._max.order + 1;
     const data: Prisma.FieldCreateInput = {
       id,
       table: {
@@ -92,6 +99,7 @@ export class FieldService implements IReadonlyAdapterService {
       notNull,
       unique,
       isPrimary,
+      order,
       version: 1,
       isComputed,
       isLookup,
@@ -220,7 +228,7 @@ export class FieldService implements IReadonlyAdapterService {
           },
         },
         {
-          createdTime: 'asc',
+          order: 'asc',
         },
       ],
     });

--- a/apps/nestjs-backend/src/features/record/record.service.ts
+++ b/apps/nestjs-backend/src/features/record/record.service.ts
@@ -507,7 +507,7 @@ export class RecordService implements IAdapterService {
       queryBuilder.orderBy(`${dbTableName}.${basicSortIndex}`, 'asc');
     }
 
-    this.logger.log('buildFilterSortQuery: %s', queryBuilder.toQuery());
+    this.logger.debug('buildFilterSortQuery: %s', queryBuilder.toQuery());
     // If you return `queryBuilder` directly and use `await` to receive it,
     // it will perform a query DB operation, which we obviously don't want to see here
     return { queryBuilder, dbTableName };
@@ -1012,7 +1012,7 @@ export class RecordService implements IAdapterService {
       queryBuilder.limit(take);
     }
 
-    this.logger.log('getRecordsQuery: %s', queryBuilder.toQuery());
+    this.logger.debug('getRecordsQuery: %s', queryBuilder.toQuery());
     const result = await this.prismaService
       .txClient()
       .$queryRawUnsafe<{ __id: string }[]>(queryBuilder.toQuery());

--- a/apps/nestjs-backend/src/features/view/view.service.ts
+++ b/apps/nestjs-backend/src/features/view/view.service.ts
@@ -416,7 +416,7 @@ export class ViewService implements IReadonlyAdapterService {
           },
         },
         {
-          createdTime: 'asc',
+          order: 'asc',
         },
       ],
     });

--- a/packages/db-main-prisma/prisma/postgres/migrations/20240409081450_field_order/migration.sql
+++ b/packages/db-main-prisma/prisma/postgres/migrations/20240409081450_field_order/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+BEGIN;
+
+-- Step 1: Add the column, allowing NULL values temporarily
+ALTER TABLE "field"
+ADD COLUMN "order" DOUBLE PRECISION;
+
+-- Step 2: Set a default value for existing rows
+UPDATE "field"
+SET "order" = 0
+WHERE "order" IS NULL;
+
+-- Step 3: Change the column to NOT NULL now that all rows have a value
+ALTER TABLE "field"
+ALTER COLUMN "order" SET NOT NULL;
+
+COMMIT;

--- a/packages/db-main-prisma/prisma/postgres/schema.prisma
+++ b/packages/db-main-prisma/prisma/postgres/schema.prisma
@@ -87,6 +87,7 @@ model Field {
   lookupLinkedFieldId String?   @map("lookup_linked_field_id")
   lookupOptions       String?   @map("lookup_options")
   tableId             String    @map("table_id")
+  order               Float
   version             Int
   createdTime         DateTime  @default(now()) @map("created_time")
   lastModifiedTime    DateTime? @updatedAt @map("last_modified_time")

--- a/packages/db-main-prisma/prisma/sqlite/migrations/20240409081445_field_order/migration.sql
+++ b/packages/db-main-prisma/prisma/sqlite/migrations/20240409081445_field_order/migration.sql
@@ -1,0 +1,43 @@
+/*
+  Warnings:
+
+  - Added the required column `order` to the `field` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_field" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "options" TEXT,
+    "type" TEXT NOT NULL,
+    "cell_value_type" TEXT NOT NULL,
+    "is_multiple_cell_value" BOOLEAN,
+    "db_field_type" TEXT NOT NULL,
+    "db_field_name" TEXT NOT NULL,
+    "not_null" BOOLEAN,
+    "unique" BOOLEAN,
+    "is_primary" BOOLEAN,
+    "is_computed" BOOLEAN,
+    "is_lookup" BOOLEAN,
+    "is_pending" BOOLEAN,
+    "has_error" BOOLEAN,
+    "lookup_linked_field_id" TEXT,
+    "lookup_options" TEXT,
+    "table_id" TEXT NOT NULL,
+    "order" REAL NOT NULL,
+    "version" INTEGER NOT NULL,
+    "created_time" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_modified_time" DATETIME,
+    "deleted_time" DATETIME,
+    "created_by" TEXT NOT NULL,
+    "last_modified_by" TEXT,
+    CONSTRAINT "field_table_id_fkey" FOREIGN KEY ("table_id") REFERENCES "table_meta" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_field" ("cell_value_type", "created_by", "created_time", "db_field_name", "db_field_type", "deleted_time", "description", "has_error", "id", "is_computed", "is_lookup", "is_multiple_cell_value", "is_pending", "is_primary", "last_modified_by", "last_modified_time", "lookup_linked_field_id", "lookup_options", "name", "not_null", "options", "table_id", "type", "unique", "version") SELECT "cell_value_type", "created_by", "created_time", "db_field_name", "db_field_type", "deleted_time", "description", "has_error", "id", "is_computed", "is_lookup", "is_multiple_cell_value", "is_pending", "is_primary", "last_modified_by", "last_modified_time", "lookup_linked_field_id", "lookup_options", "name", "not_null", "options", "table_id", "type", "unique", "version" FROM "field";
+DROP TABLE "field";
+ALTER TABLE "new_field" RENAME TO "field";
+CREATE INDEX "field_lookup_linked_field_id_idx" ON "field"("lookup_linked_field_id");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/db-main-prisma/prisma/sqlite/schema.prisma
+++ b/packages/db-main-prisma/prisma/sqlite/schema.prisma
@@ -87,6 +87,7 @@ model Field {
   lookupLinkedFieldId String?   @map("lookup_linked_field_id")
   lookupOptions       String?   @map("lookup_options")
   tableId             String    @map("table_id")
+  order               Float
   version             Int
   createdTime         DateTime  @default(now()) @map("created_time")
   lastModifiedTime    DateTime? @updatedAt @map("last_modified_time")

--- a/packages/db-main-prisma/prisma/template.prisma
+++ b/packages/db-main-prisma/prisma/template.prisma
@@ -87,6 +87,7 @@ model Field {
   lookupLinkedFieldId String?   @map("lookup_linked_field_id")
   lookupOptions       String?   @map("lookup_options")
   tableId             String    @map("table_id")
+  order               Float
   version             Int
   createdTime         DateTime  @default(now()) @map("created_time")
   lastModifiedTime    DateTime? @updatedAt @map("last_modified_time")


### PR DESCRIPTION
The previous field list order is obtained according to the field creation time, but the field creation time may be exactly the same, resulting in the field order becoming unpredictable.

With this change, the default field order (the default fields order for getting fields without passing the view Id and the default fields order for creating views) will become predictable.
