### PR TITLE
refactor: support for overriding field, view, and record permission s…

### DIFF
--- a/apps/nestjs-backend/src/app.module.ts
+++ b/apps/nestjs-backend/src/app.module.ts
@@ -1,3 +1,4 @@
+import type { ModuleMetadata } from '@nestjs/common';
 import { Module } from '@nestjs/common';
 import { AccessTokenModule } from './features/access-token/access-token.module';
 import { AggregationOpenApiModule } from './features/aggregation/open-api/aggregation-open-api.module';
@@ -23,9 +24,8 @@ import { InitBootstrapProvider } from './global/init-bootstrap.provider';
 import { LoggerModule } from './logger/logger.module';
 import { WsModule } from './ws/ws.module';
 
-@Module({
+export const appModules = {
   imports: [
-    GlobalModule,
     LoggerModule.register(),
     HealthModule,
     NextModule,
@@ -49,5 +49,17 @@ import { WsModule } from './ws/ws.module';
     ExportOpenApiModule,
   ],
   providers: [InitBootstrapProvider],
+};
+
+@Module({
+  ...appModules,
+  imports: [GlobalModule, ...appModules.imports],
 })
-export class AppModule {}
+export class AppModule {
+  static register(customModuleMetadata: ModuleMetadata) {
+    return {
+      module: AppModule,
+      ...customModuleMetadata,
+    };
+  }
+}

--- a/apps/nestjs-backend/src/features/field/field-permission.service.ts
+++ b/apps/nestjs-backend/src/features/field/field-permission.service.ts
@@ -12,7 +12,7 @@ export class FieldPermissionService {
     private readonly prismaService: PrismaService
   ) {}
 
-  async getFieldsQueryWithPermission(tableId: string, fieldsQuery: IGetFieldsQuery) {
+  async getFieldsQueryWithPermission(tableId: string, fieldsQuery?: IGetFieldsQuery) {
     const shareViewId = this.cls.get('shareViewId');
     if (shareViewId) {
       return this.getFieldsQueryWithSharePermission(tableId, fieldsQuery);
@@ -20,8 +20,8 @@ export class FieldPermissionService {
     return fieldsQuery;
   }
 
-  private async getFieldsQueryWithSharePermission(tableId: string, fieldsQuery: IGetFieldsQuery) {
-    const { viewId } = fieldsQuery;
+  private async getFieldsQueryWithSharePermission(tableId: string, fieldsQuery?: IGetFieldsQuery) {
+    const { viewId } = fieldsQuery ?? {};
     const shareViewId = this.cls.get('shareViewId');
     const view = await this.prismaService.txClient().view.findFirst({
       where: {

--- a/apps/nestjs-backend/src/features/field/field.module.ts
+++ b/apps/nestjs-backend/src/features/field/field.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DbProvider } from '../../db-provider/db.provider';
 import { CalculationModule } from '../calculation/calculation.module';
-import { FieldPermissionService } from './field-permission.service';
 import { FieldService } from './field.service';
 
 @Module({
   imports: [CalculationModule],
-  providers: [FieldService, DbProvider, FieldPermissionService],
+  providers: [FieldService, DbProvider],
   exports: [FieldService],
 })
 export class FieldModule {}

--- a/apps/nestjs-backend/src/features/record/record.module.ts
+++ b/apps/nestjs-backend/src/features/record/record.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { DbProvider } from '../../db-provider/db.provider';
 import { AttachmentsStorageModule } from '../attachments/attachments-storage.module';
 import { CalculationModule } from '../calculation/calculation.module';
-import { RecordPermissionService } from './record-permission.service';
 import { RecordService } from './record.service';
 
 @Module({
   imports: [CalculationModule, AttachmentsStorageModule],
-  providers: [RecordService, DbProvider, RecordPermissionService],
+  providers: [RecordService, DbProvider],
   exports: [RecordService],
 })
 export class RecordModule {}

--- a/apps/nestjs-backend/src/features/view/view.module.ts
+++ b/apps/nestjs-backend/src/features/view/view.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DbProvider } from '../../db-provider/db.provider';
 import { CalculationModule } from '../calculation/calculation.module';
-import { ViewPermissionService } from './view-permission.service';
 import { ViewService } from './view.service';
 
 @Module({
   imports: [CalculationModule],
-  providers: [ViewService, DbProvider, ViewPermissionService],
+  providers: [ViewService, DbProvider],
   exports: [ViewService],
 })
 export class ViewModule {}


### PR DESCRIPTION
…ervices

In order to override the service in the AppModule when it is used, you need to register the service you want to override as global.
Example: 
``` ts
const app = await NestFactory.create(
    AppModule.register({
      ...appModules,
      imports: [
        GlobalModule.register({
          providers: [{ provide: FieldPermissionService, useClass: OverrideFieldPermissionService }],
        }),
        ...appModules.imports,
      ],
    })
  );
````