### PR TITLE
chore: one-click deploy button for RepoCloud.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ These platforms are easy to deploy with one click and come with free credits.
 
 [![Deploy on Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dteable)
 
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=273)
+
 ## Development
 
 #### 1. Initialize


### PR DESCRIPTION
Adding button enabling community access to one-click deploy template for self-hosting on RepoCloud.io