### PR TITLE
fix: request not being sent when browser is offline

### DIFF
--- a/packages/sdk/src/context/app/queryClient.tsx
+++ b/packages/sdk/src/context/app/queryClient.tsx
@@ -24,6 +24,10 @@ export const createQueryClient = () => {
         // above 0 to avoid refetching immediately on the client
         staleTime: 10 * 1000,
         retry: false,
+        networkMode: 'always',
+      },
+      mutations: {
+        networkMode: 'always',
       },
     },
     queryCache: new QueryCache({


### PR DESCRIPTION
https://tanstack.com/query/v4/docs/framework/react/guides/network-mode

In react-query, the default network mode is online.