### PR TITLE
fix: Changed default value of 1 to 0 for second parameter of REPT()

### DIFF
--- a/packages/core/src/formula/functions/text.ts
+++ b/packages/core/src/formula/functions/text.ts
@@ -378,7 +378,7 @@ export class Rept extends TextFunc {
 
     if (value == null) return null;
 
-    const count = Number(params[1]?.value ?? 1);
+    const count = Number(params[1]?.value ?? 0);
     if (count === 0) return null;
     return String(value).repeat(count);
   }


### PR DESCRIPTION
If the default value is kept at 1, then the string would appear atleast once even if second parameter passed to REPT is NULL.

Before code change:
![image](https://github.com/user-attachments/assets/38561810-307a-4ed7-a8ec-6ac8d5aa0b06)

![image](https://github.com/user-attachments/assets/b323e099-5e52-4059-a6a0-57943f4bf550)

We can see that "1" is repeated once even though there is no rating


After code change:

![image](https://github.com/user-attachments/assets/9e0c7a98-d71f-4255-8025-06912636a589)

![image](https://github.com/user-attachments/assets/2a39b2b5-3f2a-477b-a557-9aff4dab238e)
