### PR TITLE
refactor: move to @httpx/dsn-parser

### DIFF
--- a/dockers/teable/Dockerfile.db-migrate
+++ b/dockers/teable/Dockerfile.db-migrate
@@ -11,7 +11,7 @@ ENV NODE_ENV=production
 ENV BUILD_VERSION=$BUILD_VERSION
 
 RUN set -eux; \
-        npm install zx @soluble/dsn-parser \
+        npm install zx @httpx/dsn-parser \
                        @prisma/client@${PRISMA_VERSION} \
                        prisma@${PRISMA_VERSION} -g; \
         apt-get update; \

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "6.4.0",
-    "@soluble/dsn-parser": "1.9.2",
+    "@httpx/dsn-parser": "1.8.4",
     "@types/color": "3.0.6",
     "@types/papaparse": "5.3.14",
     "antlr4ts": "0.5.0-alpha.4",

--- a/packages/core/src/utils/dsn-parser.ts
+++ b/packages/core/src/utils/dsn-parser.ts
@@ -1,5 +1,5 @@
-import type { parseDsnOrThrow } from '@soluble/dsn-parser';
-import { isParsableDsn as isParsable, parseDsn as parse } from '@soluble/dsn-parser';
+import type { parseDsnOrThrow } from '@httpx/dsn-parser';
+import { isParsableDsn as isParsable, parseDsn as parse } from '@httpx/dsn-parser';
 
 export type IDsn = ReturnType<typeof parseDsnOrThrow>;
 

--- a/packages/db-main-prisma/package.json
+++ b/packages/db-main-prisma/package.json
@@ -52,7 +52,7 @@
     "nanoid": "3.3.7"
   },
   "devDependencies": {
-    "@soluble/dsn-parser": "1.9.2",
+    "@httpx/dsn-parser": "1.8.4",
     "@faker-js/faker": "8.4.1",
     "@teable/eslint-config-bases": "workspace:^",
     "@types/node": "20.9.0",

--- a/packages/db-main-prisma/prisma/seed.ts
+++ b/packages/db-main-prisma/prisma/seed.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ParseArgsConfig } from 'node:util';
 import { parseArgs } from 'node:util';
-import type { parseDsnOrThrow } from '@soluble/dsn-parser';
-import { parseDsn as parse } from '@soluble/dsn-parser';
+import type { parseDsnOrThrow } from '@httpx/dsn-parser';
+import { parseDsn as parse } from '@httpx/dsn-parser';
 import { PrismaClient } from '../';
 import { SpaceSeeds } from '../src/seeds/e2e/space-seeds';
 import { UserSeeds } from '../src/seeds/e2e/user-seeds';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,9 +929,9 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: 6.4.0
         version: 6.4.0(zod@3.22.4)
-      '@soluble/dsn-parser':
-        specifier: 1.9.2
-        version: 1.9.2
+      '@httpx/dsn-parser':
+        specifier: 1.8.4
+        version: 1.8.4
       '@types/color':
         specifier: 3.0.6
         version: 3.0.6
@@ -1039,9 +1039,9 @@ importers:
       '@faker-js/faker':
         specifier: 8.4.1
         version: 8.4.1
-      '@soluble/dsn-parser':
-        specifier: 1.9.2
-        version: 1.9.2
+      '@httpx/dsn-parser':
+        specifier: 1.8.4
+        version: 1.8.4
       '@teable/eslint-config-bases':
         specifier: workspace:^
         version: link:../eslint-config-bases
@@ -6044,6 +6044,10 @@ packages:
       react-hook-form: 7.51.1(react@18.2.0)
     dev: false
 
+  /@httpx/dsn-parser@1.8.4:
+    resolution: {integrity: sha512-/8kxTR8ryQ2K9jZRmbWfrLHTJS/Eb4Mc8MicyOlK4P5aWUbLKekt4LIBWZxeq2lA10Eb04+FHpmt23A8e1C2sQ==}
+    engines: {node: '>=18'}
+
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -9700,9 +9704,6 @@ packages:
       '@smithy/types': 3.3.0
       tslib: 2.6.2
     dev: false
-
-  /@soluble/dsn-parser@1.9.2:
-    resolution: {integrity: sha512-FgkvHHHSCzjQ1/ouW6Vtw2hy0k5/KWeu116swH5VYX267I4rx+8MCy9/6eZ60IWGIQVNgh0sektKAu0n9gtzzA==}
 
   /@storybook/addon-actions@8.0.4:
     resolution: {integrity: sha512-EyCWo+8T11/TJGYNL/AXtW4yaB+q1v2E9mixbumryCLxpTl2NtaeGZ4e0dlwfIMuw/7RWgHk2uIypcIPR/UANQ==}
@@ -26808,9 +26809,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0


### PR DESCRIPTION
Hello, I'm suggesting to move @soluble/dsn-parser to @httpx/dsn-parser as I will soon deprecate the package

https://github.com/belgattitude/httpx/tree/main/packages/dsn-parser#readme

PS: I'm the author of both libraries and nextjs-monorepo-example....No BC between both

