### PR TITLE
fix: reset password page not working

### DIFF
--- a/apps/nextjs-app/src/pages/auth/forget-password.tsx
+++ b/apps/nextjs-app/src/pages/auth/forget-password.tsx
@@ -24,5 +24,5 @@ export const getServerSideProps: GetServerSideProps = withEnv(
         ...(await getTranslationsProps(context, i18nNamespaces)),
       },
     };
-  })
+  }, true)
 );

--- a/apps/nextjs-app/src/pages/auth/reset-password.tsx
+++ b/apps/nextjs-app/src/pages/auth/reset-password.tsx
@@ -24,5 +24,5 @@ export const getServerSideProps: GetServerSideProps = withEnv(
         ...(await getTranslationsProps(context, i18nNamespaces)),
       },
     };
-  })
+  }, true)
 );


### PR DESCRIPTION
The "forget password" link on main page redirects to login page, which creates an endless loop. This PR fixes that.

![bad redirect](https://github.com/user-attachments/assets/885de8ee-0015-4946-9cfa-f50e98ed98fa)
