### PR TITLE
fix: position bug on table's rename input

### DIFF
--- a/apps/nextjs-app/src/features/app/blocks/table-list/NoDraggableList.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/table-list/NoDraggableList.tsx
@@ -8,7 +8,7 @@ export const NoDraggableList: React.FC = () => {
   return (
     <ul>
       {tables.map((table) => (
-        <li key={table.id}>
+        <li key={table.id} className={'group relative cursor-pointer overflow-y-auto'}>
           <TableListItem table={table} isActive={table.id === tableId} />
         </li>
       ))}


### PR DESCRIPTION
Yet another bug I found:

[video-2024-12-04_06.07.23.webm](https://github.com/user-attachments/assets/983ec711-6c44-4ded-b5c6-1b7fff7f4bea)

 Yea... Maybe esthetic change, but this input is a few pixels too large.