### PR TITLE
feat: more context menu actions

### DIFF
--- a/apps/nextjs-app/src/features/app/blocks/space/component/SpaceActionTrigger.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/space/component/SpaceActionTrigger.tsx
@@ -20,6 +20,8 @@ interface ISpaceActionTrigger {
   onRename?: () => void;
   onDelete?: () => void;
   onSpaceSetting?: () => void;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 }
 
 export const SpaceActionTrigger: React.FC<React.PropsWithChildren<ISpaceActionTrigger>> = (
@@ -34,6 +36,8 @@ export const SpaceActionTrigger: React.FC<React.PropsWithChildren<ISpaceActionTr
     onDelete,
     onRename,
     onSpaceSetting,
+    open,
+    setOpen,
   } = props;
   const { t } = useTranslation(spaceConfig.i18nNamespaces);
   const [deleteConfirm, setDeleteConfirm] = React.useState(false);
@@ -42,7 +46,7 @@ export const SpaceActionTrigger: React.FC<React.PropsWithChildren<ISpaceActionTr
   }
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           {showRename && (

--- a/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceItem.tsx
@@ -37,11 +37,12 @@ export const SpaceItem: React.FC<IProps> = ({ space, isActive }) => {
   }, [isEditing]);
 
   useClickAway(inputRef, async () => {
-    if (isEditing && inputRef.current?.value && inputRef.current.value !== space.name)
+    if (isEditing && inputRef.current?.value && inputRef.current.value !== space.name) {
       await updateSpaceMutator({
         spaceId: space.id,
         updateSpaceRo: { name: inputRef.current.value },
       });
+    }
     setIsEditing(false);
   });
 

--- a/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceItem.tsx
@@ -1,8 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { hasPermission } from '@teable/core';
 import { Component } from '@teable/icons';
-import { PinType, type IGetSpaceVo } from '@teable/openapi';
+import { PinType, type IGetSpaceVo, updateSpace } from '@teable/openapi';
+import { ReactQueryKeys } from '@teable/sdk';
+import { Input } from '@teable/ui-lib';
 import Link from 'next/link';
-import { useRef } from 'react';
-import { useMount } from 'react-use';
+import { useEffect, useRef, useState } from 'react';
+import { useClickAway, useMount } from 'react-use';
+import { SpaceOperation } from '@/features/app/blocks/space/space-side-bar/SpaceOperation';
 import { ItemButton } from './ItemButton';
 import { StarButton } from './StarButton';
 
@@ -14,26 +19,85 @@ interface IProps {
 export const SpaceItem: React.FC<IProps> = ({ space, isActive }) => {
   const { id, name } = space;
   const ref = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const queryClient = useQueryClient();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { mutateAsync: updateSpaceMutator } = useMutation({
+    mutationFn: updateSpace,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ReactQueryKeys.spaceList() });
+      queryClient.invalidateQueries({ queryKey: ReactQueryKeys.space(space.id) });
+    },
+  });
+
+  useEffect(() => {
+    if (isEditing) setTimeout(() => inputRef.current?.focus());
+  }, [isEditing]);
+
+  useClickAway(inputRef, async () => {
+    if (isEditing && inputRef.current?.value && inputRef.current.value !== space.name)
+      await updateSpaceMutator({
+        spaceId: space.id,
+        updateSpaceRo: { name: inputRef.current.value },
+      });
+    setIsEditing(false);
+  });
 
   useMount(() => {
     isActive && ref.current?.scrollIntoView({ block: 'center' });
   });
 
   return (
-    <ItemButton className="group" isActive={isActive} ref={ref}>
-      <Link
-        href={{
-          pathname: '/space/[spaceId]',
-          query: {
-            spaceId: id,
-          },
-        }}
-        title={name}
-      >
-        <Component className="size-4 shrink-0" />
-        <p className="grow truncate">{' ' + name}</p>
-        <StarButton id={id} type={PinType.Space} />
-      </Link>
-    </ItemButton>
+    <div className="relative overflow-y-auto">
+      <ItemButton className="group" isActive={isActive} ref={ref}>
+        <Link
+          href={{
+            pathname: '/space/[spaceId]',
+            query: {
+              spaceId: id,
+            },
+          }}
+          title={name}
+          onContextMenu={() => setOpen(true)}
+          onDoubleClick={() => hasPermission(space.role, 'space|update') && setIsEditing(true)}
+        >
+          <Component className="size-4 shrink-0" />
+          <p className="grow truncate">{' ' + name}</p>
+          <StarButton id={id} type={PinType.Space} />
+
+          <SpaceOperation
+            space={space}
+            onRename={() => setIsEditing(true)}
+            open={open}
+            setOpen={setOpen}
+            className="size-4 shrink-0 sm:opacity-0 sm:group-hover:opacity-100"
+          />
+        </Link>
+      </ItemButton>
+      {isEditing && (
+        <Input
+          ref={inputRef}
+          type="text"
+          placeholder="name"
+          defaultValue={space.name}
+          style={{
+            boxShadow: 'none',
+          }}
+          className="round-none absolute left-0 top-0 size-full cursor-text bg-background px-4 outline-none"
+          onKeyDown={async (e) => {
+            if (e.key === 'Enter') {
+              if (e.currentTarget.value && e.currentTarget.value !== space.name)
+                await updateSpaceMutator({
+                  spaceId: space.id,
+                  updateSpaceRo: { name: e.currentTarget.value },
+                });
+              setIsEditing(false);
+            }
+          }}
+        />
+      )}
+    </div>
   );
 };

--- a/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceOperation.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/space/space-side-bar/SpaceOperation.tsx
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { hasPermission } from '@teable/core';
+import { MoreHorizontal } from '@teable/icons';
+import { deleteSpace, type IGetSpaceVo } from '@teable/openapi';
+import { ReactQueryKeys } from '@teable/sdk/config';
+import { useRouter } from 'next/router';
+import React, { useMemo } from 'react';
+import { SpaceActionTrigger } from '@/features/app/blocks/space/component/SpaceActionTrigger';
+
+interface ISpaceOperationProps {
+  className?: string;
+  space: IGetSpaceVo;
+  onRename?: () => void;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
+}
+
+export const SpaceOperation = (props: ISpaceOperationProps) => {
+  const { space, className, onRename, open, setOpen } = props;
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const menuPermission = useMemo(() => {
+    return {
+      spaceUpdate: hasPermission(space.role, 'space|update'),
+      spaceDelete: hasPermission(space.role, 'space|delete'),
+    };
+  }, [space.role]);
+
+  const { mutate: deleteSpaceMutator } = useMutation({
+    mutationFn: deleteSpace,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ReactQueryKeys.spaceList() });
+    },
+  });
+
+  const onSpaceSetting = () => {
+    router.push({
+      pathname: '/space/[spaceId]/setting/general',
+      query: { spaceId: space.id },
+    });
+  };
+
+  if (!Object.values(menuPermission).some(Boolean)) {
+    return null;
+  }
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
+    >
+      <SpaceActionTrigger
+        space={space}
+        showRename={menuPermission.spaceUpdate}
+        showDelete={menuPermission.spaceDelete}
+        showSpaceSetting={menuPermission.spaceUpdate}
+        onDelete={() => deleteSpaceMutator(space.id)}
+        onRename={onRename}
+        onSpaceSetting={onSpaceSetting}
+        open={open}
+        setOpen={setOpen}
+      >
+        <div>
+          <MoreHorizontal className={className} />
+        </div>
+      </SpaceActionTrigger>
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/app/blocks/table-list/TableListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/table-list/TableListItem.tsx
@@ -47,8 +47,9 @@ export const TableListItem: React.FC<IProps> = ({ table, isActive, className, is
   }, [isEditing]);
 
   useClickAway(inputRef, () => {
-    if (isEditing && inputRef.current?.value && inputRef.current.value !== table.name)
+    if (isEditing && inputRef.current?.value && inputRef.current.value !== table.name) {
       table.updateName(inputRef.current.value);
+    }
     setIsEditing(false);
   });
 

--- a/apps/nextjs-app/src/features/app/blocks/table-list/TableListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/table-list/TableListItem.tsx
@@ -4,6 +4,7 @@ import { Button, cn } from '@teable/ui-lib/shadcn';
 import { Input } from '@teable/ui-lib/shadcn/ui/input';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
+import { useClickAway } from 'react-use';
 import { Emoji } from '../../components/emoji/Emoji';
 import { EmojiPicker } from '../../components/emoji/EmojiPicker';
 import { TableOperation } from './TableOperation';
@@ -13,10 +14,12 @@ interface IProps {
   isActive: boolean;
   isDragging?: boolean;
   className?: string;
+  open?: boolean;
 }
 
 export const TableListItem: React.FC<IProps> = ({ table, isActive, className, isDragging }) => {
   const [isEditing, setIsEditing] = useState(false);
+  const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const { baseId } = router.query;
@@ -43,6 +46,12 @@ export const TableListItem: React.FC<IProps> = ({ table, isActive, className, is
     }
   }, [isEditing]);
 
+  useClickAway(inputRef, () => {
+    if (isEditing && inputRef.current?.value && inputRef.current.value !== table.name)
+      table.updateName(inputRef.current.value);
+    setIsEditing(false);
+  });
+
   return (
     <>
       <Button
@@ -57,6 +66,7 @@ export const TableListItem: React.FC<IProps> = ({ table, isActive, className, is
           }
         )}
         onClick={navigateHandler}
+        onContextMenu={() => setOpen(true)}
       >
         <div>
           {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
@@ -86,6 +96,8 @@ export const TableListItem: React.FC<IProps> = ({ table, isActive, className, is
               table={table}
               className="size-4 shrink-0 sm:opacity-0 sm:group-hover:opacity-100"
               onRename={() => setIsEditing(true)}
+              open={open}
+              setOpen={setOpen}
             />
           )}
         </div>
@@ -100,12 +112,6 @@ export const TableListItem: React.FC<IProps> = ({ table, isActive, className, is
             boxShadow: 'none',
           }}
           className="round-none absolute left-0 top-0 size-full cursor-text bg-background px-4 outline-none"
-          onBlur={(e) => {
-            if (e.target.value && e.target.value !== table.name) {
-              table.updateName(e.target.value);
-            }
-            setIsEditing(false);
-          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               if (e.currentTarget.value && e.currentTarget.value !== table.name) {

--- a/apps/nextjs-app/src/features/app/blocks/table-list/TableOperation.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/table-list/TableOperation.tsx
@@ -36,10 +36,12 @@ interface ITableOperationProps {
   className?: string;
   table: Table;
   onRename?: () => void;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 }
 
 export const TableOperation = (props: ITableOperationProps) => {
-  const { table, className, onRename } = props;
+  const { table, className, onRename, open, setOpen } = props;
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [importVisible, setImportVisible] = useState(false);
   const [importType, setImportType] = useState(SUPPORTEDTYPE.CSV);
@@ -91,7 +93,7 @@ export const TableOperation = (props: ITableOperationProps) => {
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div onMouseDown={(e) => e.stopPropagation()}>
-      <DropdownMenu>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>
           <div>
             <MoreHorizontal className={className} />

--- a/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   cn,
+  PopoverAnchor,
 } from '@teable/ui-lib/shadcn';
 import { Input } from '@teable/ui-lib/shadcn/ui/input';
 import Image from 'next/image';
@@ -57,7 +58,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
   };
   const ViewIcon = VIEW_ICON_MAP[view.type];
 
-  const showViewMenu = permission['view|delete'] || permission['view|update'];
+  const showViewMenu = !isEditing && (permission['view|delete'] || permission['view|update']);
 
   const commonPart = (
     <div className="relative flex w-full items-center overflow-hidden px-0.5">
@@ -72,17 +73,9 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
       ) : (
         <ViewIcon className="mr-1 size-4 shrink-0" />
       )}
-      {isActive && showViewMenu ? (
-        <PopoverTrigger asChild>
-          <div className="flex flex-1 items-center justify-center overflow-hidden">
-            <div className="truncate text-xs font-medium leading-5">{view.name}</div>
-          </div>
-        </PopoverTrigger>
-      ) : (
-        <div className="flex flex-1 items-center justify-center overflow-hidden">
-          <div className="truncate text-xs font-medium leading-5">{view.name}</div>
-        </div>
-      )}
+      <div className="flex flex-1 items-center justify-center overflow-hidden">
+        <div className="truncate text-xs font-medium leading-5">{view.name}</div>
+      </div>
       {isEditing && (
         <Input
           type="text"
@@ -138,6 +131,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
         }
         navigateHandler();
       }}
+      onContextMenu={() => showViewMenu && setOpen(true)}
     >
       <Popover open={open} onOpenChange={setOpen}>
         <Button
@@ -147,10 +141,15 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
             'bg-secondary': isActive,
           })}
         >
-          {commonPart}
+          {isActive && showViewMenu ? (
+            <PopoverTrigger asChild>{commonPart}</PopoverTrigger>
+          ) : (
+            <PopoverAnchor asChild>{commonPart}</PopoverAnchor>
+          )}
         </Button>
         <PopoverContent className="w-32 p-1">
-          <div className="flex flex-col">
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+          <div className="flex flex-col" onClick={(ev) => ev.stopPropagation()}>
             {permission['view|update'] && (
               <Button
                 size="xs"

--- a/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
@@ -159,7 +159,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
                 }}
                 className="flex justify-start"
               >
-                <Pencil className="size-3" />
+                <Pencil className="size-3 shrink-0" />
                 {t('view.action.rename')}
               </Button>
             )}
@@ -172,7 +172,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
                 }}
                 className="flex justify-start"
               >
-                <Export className="size-3" />
+                <Export className="size-3 shrink-0" />
                 {t('import.menu.downAsCsv')}
               </Button>
             )}
@@ -205,7 +205,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
                     deleteView();
                   }}
                 >
-                  <Trash2 className="size-3" />
+                  <Trash2 className="size-3 shrink-0" />
                   {t('view.action.delete')}
                 </Button>
               </>

--- a/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
@@ -147,71 +147,73 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive }) =>
             <PopoverAnchor asChild>{commonPart}</PopoverAnchor>
           )}
         </Button>
-        <PopoverContent className="w-32 p-1">
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-          <div className="flex flex-col" onClick={(ev) => ev.stopPropagation()}>
-            {permission['view|update'] && (
-              <Button
-                size="xs"
-                variant="ghost"
-                onClick={() => {
-                  setIsEditing(true);
-                }}
-                className="flex justify-start"
-              >
-                <Pencil className="size-3 shrink-0" />
-                {t('view.action.rename')}
-              </Button>
-            )}
-            {view.type === 'grid' && permission['view|read'] && (
-              <Button
-                size="xs"
-                variant="ghost"
-                onClick={() => {
-                  trigger?.();
-                }}
-                className="flex justify-start"
-              >
-                <Export className="size-3 shrink-0" />
-                {t('import.menu.downAsCsv')}
-              </Button>
-            )}
-            {permission['view|create'] && (
-              <>
+        {open && (
+          <PopoverContent className="w-32 p-1">
+            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+            <div className="flex flex-col" onClick={(ev) => ev.stopPropagation()}>
+              {permission['view|update'] && (
                 <Button
                   size="xs"
                   variant="ghost"
-                  onClick={async () => {
-                    await duplicateView();
-                    setOpen(false);
+                  onClick={() => {
+                    setIsEditing(true);
                   }}
                   className="flex justify-start"
                 >
-                  <Copy className="size-3" />
-                  {t('view.action.duplicate')}
+                  <Pencil className="size-3 shrink-0" />
+                  {t('view.action.rename')}
                 </Button>
-              </>
-            )}
-            {permission['view|delete'] && (
-              <>
-                <Separator className="my-0.5" />
+              )}
+              {view.type === 'grid' && permission['view|read'] && (
                 <Button
                   size="xs"
-                  disabled={!removable}
                   variant="ghost"
-                  className="flex justify-start text-red-500"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    deleteView();
+                  onClick={() => {
+                    trigger?.();
                   }}
+                  className="flex justify-start"
                 >
-                  <Trash2 className="size-3 shrink-0" />
-                  {t('view.action.delete')}
+                  <Export className="size-3 shrink-0" />
+                  {t('import.menu.downAsCsv')}
                 </Button>
-              </>
-            )}
-          </div>
-        </PopoverContent>
+              )}
+              {permission['view|create'] && (
+                <>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={async () => {
+                      await duplicateView();
+                      setOpen(false);
+                    }}
+                    className="flex justify-start"
+                  >
+                    <Copy className="size-3" />
+                    {t('view.action.duplicate')}
+                  </Button>
+                </>
+              )}
+              {permission['view|delete'] && (
+                <>
+                  <Separator className="my-0.5" />
+                  <Button
+                    size="xs"
+                    disabled={!removable}
+                    variant="ghost"
+                    className="flex justify-start text-red-500"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      deleteView();
+                    }}
+                  >
+                    <Trash2 className="size-3 shrink-0" />
+                    {t('view.action.delete')}
+                  </Button>
+                </>
+              )}
+            </div>
+          </PopoverContent>
+        )}
       </Popover>
       <iframe ref={iframeRef} title="This for export csv download" style={{ display: 'none' }} />
     </div>


### PR DESCRIPTION
Closes #1123

1. Added context menu to space selection: ![](https://github.com/user-attachments/assets/07ae7942-7a5c-4bf8-ad30-785624ad7903)

![](https://github.com/user-attachments/assets/95ca65d7-0aa2-4a18-9d7e-919b5e7ab2e3)

2. Added right-click action to open this context menu
3. Added right-click action to table selection menu
![](https://github.com/user-attachments/assets/89d4f60c-eac3-4e94-b618-9269bbb918ab)

5. Replaced onBlur with useClickAway, because table rename via context menu caused troubles in Firefox
6. Added right-click action to views
![obraz](https://github.com/user-attachments/assets/6feec0fd-259c-4b38-945d-2a50ea3a6a51)
7. Made PopoverTrigger slightly bigger there, so you can click on view's button edge and still open context menu