### PR TITLE
feat: support shift+tab hotkey

### DIFF
--- a/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
+++ b/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
@@ -120,10 +120,14 @@ export const useKeyboardSelection = (props: ISelectionKeyboardProps) => {
   );
 
   useHotkeys(
-    'tab',
+    ['tab', 'shift+tab'],
     () => {
       const [columnIndex, rowIndex] = selection.ranges[0];
-      const newColumnIndex = Math.min(columnIndex + 1, columnCount - 1);
+
+      let newColumnIndex = Math.min(columnIndex + 1, columnCount - 1);
+      if (isHotkeyPressed('shift') && isHotkeyPressed('tab'))
+        newColumnIndex = Math.max(columnIndex - 1, 0);
+
       const newRange = <IRange>[newColumnIndex, rowIndex];
       const ranges = [newRange, newRange];
 


### PR DESCRIPTION
This pull request enhances the keyboard navigation functionality within the grid component by adding support for reverse tabbing using the 'shift+tab' key combination.

Keyboard navigation improvements:

* [`packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts`](diffhunk://#diff-f8986b6dfefdde6dabeb3076411091faf53392d742f3d69f5b991a3ed97fd98aL123-R130): Modified the `useHotkeys` hook to handle both 'tab' and 'shift+tab' key combinations, allowing users to navigate backward through the grid columns when 'shift+tab' is pressed.

Related: @nicholas-mn in https://github.com/teableio/teable/issues/1074#issuecomment-2488139436
Change was tested locally.