### PR TITLE
feat: pageUp/pageDown scrolling support

### DIFF
--- a/packages/sdk/src/components/grid/InteractionLayer.tsx
+++ b/packages/sdk/src/components/grid/InteractionLayer.tsx
@@ -791,6 +791,7 @@ export const InteractionLayerBase: ForwardRefRenderFunction<
         getCellContent={getCellContent}
         real2RowIndex={real2RowIndex}
         scrollToItem={scrollToItem}
+        scrollBy={scrollBy}
       />
     </div>
   );

--- a/packages/sdk/src/components/grid/components/editor/EditorContainer.tsx
+++ b/packages/sdk/src/components/grid/components/editor/EditorContainer.tsx
@@ -36,6 +36,7 @@ export interface IEditorContainerProps
     | 'onDelete'
     | 'onRowAppend'
     | 'onRowExpand'
+    | 'scrollBy'
   > {
   isEditing?: boolean;
   scrollState: IScrollState;
@@ -97,6 +98,7 @@ export const EditorContainerBase: ForwardRefRenderFunction<
     setSelection,
     real2RowIndex,
     getCellContent,
+    scrollBy,
   } = props;
   const { scrollLeft, scrollTop } = scrollState;
   const { rowIndex, realRowIndex, columnIndex } = useMemo(() => {
@@ -148,6 +150,7 @@ export const EditorContainerBase: ForwardRefRenderFunction<
     setActiveCell,
     setSelection,
     scrollToItem,
+    scrollBy,
   });
 
   const editorStyle = useMemo(

--- a/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
+++ b/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
@@ -32,6 +32,7 @@ export const useKeyboardSelection = (props: ISelectionKeyboardProps) => {
     onDelete,
     onRowExpand,
     editorRef,
+    scrollBy,
   } = props;
   const { pureRowCount, columnCount } = coordInstance;
 
@@ -143,6 +144,17 @@ export const useKeyboardSelection = (props: ISelectionKeyboardProps) => {
     }
   );
 
+  useHotkeys(
+    ['PageUp', 'PageDown'],
+    () => {
+      const delta = coordInstance.containerHeight - coordInstance.rowInitSize - 1;
+      scrollBy(0, isHotkeyPressed('PageUp') ? -delta : delta);
+    },
+    {
+      enabled: !isEditing,
+      enableOnFormTags: ['input', 'select', 'textarea'],
+    }
+  );
   useHotkeys(
     'mod+a',
     () => {

--- a/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
+++ b/packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts
@@ -151,7 +151,7 @@ export const useKeyboardSelection = (props: ISelectionKeyboardProps) => {
       scrollBy(0, isHotkeyPressed('PageUp') ? -delta : delta);
     },
     {
-      enabled: !isEditing,
+      enabled: Boolean(activeCell && !isEditing),
       enableOnFormTags: ['input', 'select', 'textarea'],
     }
   );


### PR DESCRIPTION
This PR introduces support for `PageUp` and `PageDown` key navigation in the grid view. Similar to other spreadsheets, these keys allow users to scroll vertically by one full viewport at a time, enhancing usability for large datasets.