### PR TITLE
fix: datetime isNot filter

### DIFF
--- a/apps/nestjs-backend/src/db-provider/filter-query/postgres/cell-value-filter/multiple-value/multiple-datetime-cell-value-filter.adapter.ts
+++ b/apps/nestjs-backend/src/db-provider/filter-query/postgres/cell-value-filter/multiple-value/multiple-datetime-cell-value-filter.adapter.ts
@@ -27,12 +27,15 @@ export class MultipleDatetimeCellValueFilterAdapter extends CellValueFilterPostg
     const { options } = this.field;
 
     const dateTimeRange = this.getFilterDateTimeRange(options as IDateFieldOptions, value);
-    builderClient
-      .whereRaw(
-        `NOT ??::jsonb @\\? '$[*] \\? (@ >= "${dateTimeRange[0]}" && @ <= "${dateTimeRange[1]}")'`,
-        [this.tableColumnRef]
-      )
-      .orWhereNull(this.tableColumnRef);
+    builderClient.where((builder) => {
+      builder
+        .whereRaw(
+          `NOT ??::jsonb @\\? '$[*] \\? (@ >= "${dateTimeRange[0]}" && @ <= "${dateTimeRange[1]}")'`,
+          [this.tableColumnRef]
+        )
+        .orWhereNull(this.tableColumnRef);
+    });
+
     return builderClient;
   }
 

--- a/apps/nestjs-backend/src/db-provider/filter-query/postgres/cell-value-filter/single-value/datetime-cell-value-filter.adapter.ts
+++ b/apps/nestjs-backend/src/db-provider/filter-query/postgres/cell-value-filter/single-value/datetime-cell-value-filter.adapter.ts
@@ -24,9 +24,12 @@ export class DatetimeCellValueFilterAdapter extends CellValueFilterPostgres {
     const { options } = this.field;
 
     const dateTimeRange = this.getFilterDateTimeRange(options as IDateFieldOptions, value);
-    builderClient
-      .whereNotBetween(this.tableColumnRef, dateTimeRange)
-      .orWhereNull(this.tableColumnRef);
+
+    // Wrap conditions in a nested `.where()` to ensure proper SQL grouping with parentheses,
+    // generating `WHERE ("data" NOT BETWEEN ... OR "data" IS NULL) AND other_query`.
+    builderClient.where((builder) => {
+      builder.whereNotBetween(this.tableColumnRef, dateTimeRange).orWhereNull(this.tableColumnRef);
+    });
     return builderClient;
   }
 

--- a/apps/nestjs-backend/src/db-provider/filter-query/sqlite/cell-value-filter/single-value/datetime-cell-value-filter.adapter.ts
+++ b/apps/nestjs-backend/src/db-provider/filter-query/sqlite/cell-value-filter/single-value/datetime-cell-value-filter.adapter.ts
@@ -24,9 +24,9 @@ export class DatetimeCellValueFilterAdapter extends CellValueFilterSqlite {
     const { options } = this.field;
 
     const dateTimeRange = this.getFilterDateTimeRange(options as IDateFieldOptions, value);
-    builderClient
-      .whereNotBetween(this.tableColumnRef, dateTimeRange)
-      .orWhereNull(this.tableColumnRef);
+    builderClient.where((builder) => {
+      builder.whereNotBetween(this.tableColumnRef, dateTimeRange).orWhereNull(this.tableColumnRef);
+    });
     return builderClient;
   }
 


### PR DESCRIPTION
Closes GH-1157 

This pull request addresses an issue in the SQL query construction for "is not" filter applied to Date fields. Previously, the generated SQL lacked proper grouping (via parentheses), leading to incorrect logical evaluation of combined filters. This fix ensures that logical conditions are correctly grouped, allowing filters to work as expected.