### PR TITLE
translation: add ja, ru, fr locales to calendar

### DIFF
--- a/apps/nextjs-app/src/features/app/blocks/view/calendar/components/Calendar.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/calendar/components/Calendar.tsx
@@ -49,6 +49,7 @@ const FULL_CALENDAR_LOCALE_MAP = {
   fr: frLocale,
 };
 
+// Remember to update in @sdk/src/components/editor/date/EditorMain.tsx
 const DATE_PICKER_LOCAL_MAP = {
   zh: zhCN,
   en: enUS,

--- a/packages/sdk/src/components/editor/date/EditorMain.tsx
+++ b/packages/sdk/src/components/editor/date/EditorMain.tsx
@@ -1,6 +1,6 @@
 import { type IDateFieldOptions, TimeFormatting } from '@teable/core';
 import { Button, Calendar, Input } from '@teable/ui-lib';
-import { enUS, zhCN } from 'date-fns/locale';
+import { enUS, zhCN, ja, ru, fr } from 'date-fns/locale';
 import { formatInTimeZone, toDate, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import type { ForwardRefRenderFunction } from 'react';
 import { forwardRef, useContext, useImperativeHandle, useMemo, useRef, useState } from 'react';
@@ -14,9 +14,13 @@ export interface IDateEditorMain extends ICellEditor<string | null> {
   disableTimePicker?: boolean;
 }
 
+// Remember to update in @nextjs-app/src/features/app/blocks/view/calendar/components/Calendar.tsx
 const LOCAL_MAP = {
   zh: zhCN,
   en: enUS,
+  ja: ja,
+  ru: ru,
+  fr: fr,
 };
 
 const DateEditorMainBase: ForwardRefRenderFunction<IEditorRef<string>, IDateEditorMain> = (


### PR DESCRIPTION
Fixes bug reported by @InsaneCake on https://github.com/teableio/teable/issues/1152#issuecomment-2538539911

>  in my case i should have ru-RU locale, but datepicker in cell still starts from sunday and not translated to russian.
