### PR TITLE
fix: missing cross-base link fields when update dbTableName

### DIFF
--- a/apps/nestjs-backend/src/db-provider/db.provider.interface.ts
+++ b/apps/nestjs-backend/src/db-provider/db.provider.interface.ts
@@ -1,4 +1,4 @@
-import type { DriverClient, IFilter, ISortItem } from '@teable/core';
+import type { DriverClient, IFilter, ILookupOptionsVo, ISortItem } from '@teable/core';
 import type { Prisma } from '@teable/db-main-prisma';
 import type { IAggregationField, ISearchIndexByQueryRo } from '@teable/openapi';
 import type { Knex } from 'knex';
@@ -162,4 +162,8 @@ export interface IDbProvider {
     qb: Knex.QueryBuilder,
     props: ICalendarDailyCollectionQueryProps
   ): Knex.QueryBuilder;
+
+  lookupOptionsQuery(optionsKey: keyof ILookupOptionsVo, value: string): string;
+
+  optionsQuery(optionsKey: string, value: string): string;
 }

--- a/apps/nestjs-backend/src/db-provider/postgres.provider.ts
+++ b/apps/nestjs-backend/src/db-provider/postgres.provider.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Logger } from '@nestjs/common';
-import type { IFilter, ISortItem } from '@teable/core';
+import type { IFilter, ILookupOptionsVo, ISortItem } from '@teable/core';
 import { DriverClient } from '@teable/core';
 import type { PrismaClient } from '@teable/db-main-prisma';
 import type { IAggregationField, ISearchIndexByQueryRo } from '@teable/openapi';
@@ -417,5 +417,27 @@ export class PostgresProvider implements IDbProvider {
       })
       .groupBy('dates.date')
       .orderBy('dates.date', 'asc');
+  }
+
+  // select id and lookup_options for "field" table options is a json saved in string format, match optionsKey and value
+  // please use json method in postgres
+  lookupOptionsQuery(optionsKey: keyof ILookupOptionsVo, value: string): string {
+    return this.knex('field')
+      .select({
+        id: 'id',
+        lookupOptions: 'lookup_options',
+      })
+      .whereRaw(`lookup_options::json->>'${optionsKey}' = ?`, [value])
+      .toQuery();
+  }
+
+  optionsQuery(optionsKey: string, value: string): string {
+    return this.knex('field')
+      .select({
+        id: 'id',
+        options: 'options',
+      })
+      .whereRaw(`options::json->>'${optionsKey}' = ?`, [value])
+      .toQuery();
   }
 }

--- a/apps/nestjs-backend/src/db-provider/sqlite.provider.ts
+++ b/apps/nestjs-backend/src/db-provider/sqlite.provider.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Logger } from '@nestjs/common';
-import type { IFilter, ISortItem } from '@teable/core';
+import type { IFilter, ILookupOptionsVo, ISortItem } from '@teable/core';
 import { DriverClient } from '@teable/core';
 import type { PrismaClient } from '@teable/db-main-prisma';
 import type { IAggregationField, ISearchIndexByQueryRo } from '@teable/openapi';
@@ -374,5 +374,27 @@ export class SqliteProvider implements IDbProvider {
       })
       .groupBy('d.date')
       .orderBy('d.date', 'asc');
+  }
+
+  // select id and lookup_options for "field" table options is a json saved in string format, match optionsKey and value
+  // please use json method in sqlite
+  lookupOptionsQuery(optionsKey: keyof ILookupOptionsVo, value: string): string {
+    return this.knex('field')
+      .select({
+        id: 'id',
+        lookupOptions: 'lookup_options',
+      })
+      .whereRaw(`json_extract(lookup_options, '$."${optionsKey}"') = ?`, [value])
+      .toQuery();
+  }
+
+  optionsQuery(optionsKey: string, value: string): string {
+    return this.knex('field')
+      .select({
+        id: 'id',
+        options: 'options',
+      })
+      .whereRaw(`json_extract(options, '$."${optionsKey}"') = ?`, [value])
+      .toQuery();
   }
 }


### PR DESCRIPTION
<img width="536" alt="image" src="https://github.com/user-attachments/assets/4091dbbd-21fc-44bf-a537-0338d6cff394" />

If the current table is associated with the link field or lookup field of another base, modifying dbTableName will lead to a 500 error in modifying the link field cell.

In the original code, when updating the database name, the fkHostTableName in the relevant link field and lookup field was updated. However, the code query condition restricts only querying the field information under the current baseId. But since the cross-base link was introduced later, the fkHostTableName may come from different bases. At this time, a query of global fields is needed to ensure that the modification is correct.
 