### PR TITLE
fix: calendar border color for dark mode

### DIFF
--- a/apps/nextjs-app/src/styles/global.css
+++ b/apps/nextjs-app/src/styles/global.css
@@ -6,6 +6,7 @@
   --btn-text-case: none;
   --focus-border: hsl(var(--primary)) !important;
   --separator-border: hsl(var(--border)) !important;
+  --fc-border-color: hsl(var(--border));
 }
 
 svg.icon {


### PR DESCRIPTION
Fixed border color for calendar in dark mode

Before
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/e5c406d2-57b0-491a-b5a3-241473530e88" />

After
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/f885597d-240e-4c75-9fcb-6e3e978b3345" />
