### PR TITLE
fix: special characters in passwords

### DIFF
--- a/packages/openapi/src/auth/types.ts
+++ b/packages/openapi/src/auth/types.ts
@@ -5,6 +5,6 @@ export const passwordSchema = z.string().min(8).openapi({
 });
 
 export const signupPasswordSchema = passwordSchema.regex(
-  /^(?=.*[A-Z])(?=.*\d)[A-Z\d]{8,}$/i,
+  /^(?=.*[A-Z])(?=.*\d).{8,}$/i,
   'Must contain at least one letter and one number'
 );


### PR DESCRIPTION
## Issue

There is no support for special characters, during signup I wrote `P@ssw0rd` in the password field and got rejected, with a confusing error message "Must contain at least one letter and one number".

## Changes
![](https://github.com/user-attachments/assets/6bdb956f-b560-401e-9681-f7f5464ecfda)

## Alternatives
If there is a reason why you don't allow all characters, please consider:
```js
export const signupPasswordSchema = passwordSchema.regex(
  /^(?=.*[A-Z])(?=.*\d)[\w*#@!$%^&()+=\-{}[\]:;'"<>,.?\\\/|`~]{8,}$/i,
  'Must use alphanumeric characters with at least one letter and one number'
);
```
or with unicode support:
```js
export const signupPasswordSchema = passwordSchema.regex(
  /^(?=.*\p{L})(?=.*\p{Nd})[\p{L}\p{Nd}*#@!$%^&()_+=\-{}:;'"<>,.?\\/|`~]{8,}$/iu,
  'Must contain at least one uppercase letter and one number'
);
```