### PR TITLE
chore: add minio region support

### DIFF
--- a/apps/nestjs-backend/src/configs/storage.ts
+++ b/apps/nestjs-backend/src/configs/storage.ts
@@ -18,6 +18,7 @@ export const storageConfig = registerAs('storage', () => ({
     useSSL: process.env.BACKEND_STORAGE_MINIO_USE_SSL === 'true',
     accessKey: process.env.BACKEND_STORAGE_MINIO_ACCESS_KEY,
     secretKey: process.env.BACKEND_STORAGE_MINIO_SECRET_KEY,
+    region: process.env.BACKEND_STORAGE_MINIO_REGION,
   },
   s3: {
     region: process.env.BACKEND_STORAGE_S3_REGION!,

--- a/apps/nestjs-backend/src/features/attachments/plugins/minio.ts
+++ b/apps/nestjs-backend/src/features/attachments/plugins/minio.ts
@@ -17,7 +17,7 @@ export class MinioStorage implements StorageAdapter {
   minioClientPrivateNetwork: minio.Client;
 
   constructor(@StorageConfig() readonly config: IStorageConfig) {
-    const { endPoint, internalEndPoint, internalPort, port, useSSL, accessKey, secretKey } =
+    const { endPoint, internalEndPoint, internalPort, port, useSSL, accessKey, secretKey, region } =
       this.config.minio;
     this.minioClient = new minio.Client({
       endPoint: endPoint!,
@@ -25,6 +25,7 @@ export class MinioStorage implements StorageAdapter {
       useSSL: useSSL!,
       accessKey: accessKey!,
       secretKey: secretKey!,
+      region: region,
     });
     this.minioClientPrivateNetwork = internalEndPoint
       ? new minio.Client({
@@ -33,6 +34,7 @@ export class MinioStorage implements StorageAdapter {
           useSSL: false,
           accessKey: accessKey!,
           secretKey: secretKey!,
+          region: region,
         })
       : this.minioClient;
     fse.ensureDirSync(StorageAdapter.TEMPORARY_DIR);

--- a/apps/nextjs-app/.env.example
+++ b/apps/nextjs-app/.env.example
@@ -28,6 +28,8 @@ BACKEND_STORAGE_MINIO_INTERNAL_PORT=9000
 BACKEND_STORAGE_MINIO_USE_SSL=true
 BACKEND_STORAGE_MINIO_ACCESS_KEY=access-key
 BACKEND_STORAGE_MINIO_SECRET_KEY=secrect-key
+# minio region, optional
+BACKEND_STORAGE_MINIO_REGION=us-east-1
 
 # storage prefix, default is PUBLIC_ORIGIN, if you want to use minio storage, you need to set this value
 STORAGE_PREFIX=http://localhost:3000


### PR DESCRIPTION
Add `BACKEND_STORAGE_MINIO_REGION` env to config region if minio instance is not using default region config.