### PR TITLE
feat: expose error for oidc strategy for debugging with oauth2

### DIFF
--- a/apps/nestjs-backend/src/features/auth/strategies/oidc.strategy.ts
+++ b/apps/nestjs-backend/src/features/auth/strategies/oidc.strategy.ts
@@ -25,6 +25,10 @@ export class OIDCStrategy extends PassportStrategy(Strategy, 'openidconnect') {
     });
   }
 
+  error(err: Error) {
+    console.error('OIDCStrategy error', err);
+  }
+
   async validate(_issuer: string, profile: Profile) {
     const { id, emails, displayName, photos } = profile;
     const email = emails?.[0].value;


### PR DESCRIPTION
Currently the oidc strategy would not expose the error message from openidconnect plugin from passport.js, after adding the error() method to the OIDCStrategy class, it would be helpful for users to debug their OIDC configurations.