### PR TITLE
feat/erd

### DIFF
--- a/apps/nestjs-backend/src/features/base/base.controller.ts
+++ b/apps/nestjs-backend/src/features/base/base.controller.ts
@@ -344,7 +344,7 @@ export class BaseController {
     await this.baseService.moveBase(baseId, moveBaseRo);
   }
 
-  @Permissions('base|read')
+  @Permissions('base|update')
   @Get(':baseId/erd')
   async generateBaseErd(@Param('baseId') baseId: string): Promise<IBaseErdVo> {
     return await this.baseService.generateBaseErd(baseId);

--- a/apps/nestjs-backend/src/features/base/base.controller.ts
+++ b/apps/nestjs-backend/src/features/base/base.controller.ts
@@ -37,6 +37,7 @@ import {
 import type {
   CreateBaseInvitationLinkVo,
   EmailInvitationVo,
+  IBaseErdVo,
   ICreateBaseVo,
   IDbConnectionVo,
   IGetBaseAllVo,
@@ -341,5 +342,11 @@ export class BaseController {
     @Body(new ZodValidationPipe(moveBaseRoSchema)) moveBaseRo: IMoveBaseRo
   ) {
     await this.baseService.moveBase(baseId, moveBaseRo);
+  }
+
+  @Permissions('base|read')
+  @Get(':baseId/erd')
+  async generateBaseErd(@Param('baseId') baseId: string): Promise<IBaseErdVo> {
+    return await this.baseService.generateBaseErd(baseId);
   }
 }

--- a/apps/nestjs-backend/src/features/base/base.module.ts
+++ b/apps/nestjs-backend/src/features/base/base.module.ts
@@ -5,6 +5,7 @@ import { CollaboratorModule } from '../collaborator/collaborator.module';
 import { FieldDuplicateModule } from '../field/field-duplicate/field-duplicate.module';
 import { FieldModule } from '../field/field.module';
 import { FieldOpenApiModule } from '../field/open-api/field-open-api.module';
+import { GraphModule } from '../graph/graph.module';
 import { InvitationModule } from '../invitation/invitation.module';
 import { NotificationModule } from '../notification/notification.module';
 import { RecordModule } from '../record/record.module';
@@ -40,6 +41,7 @@ import { DbConnectionService } from './db-connection.service';
     BaseImportAttachmentsModule,
     BaseImportCsvModule,
     BaseImportAttachmentsCsvModule,
+    GraphModule,
   ],
   providers: [
     DbProvider,

--- a/apps/nestjs-backend/src/features/base/base.service.ts
+++ b/apps/nestjs-backend/src/features/base/base.service.ts
@@ -9,6 +9,7 @@ import { ActionPrefix, actionPrefixMap, generateBaseId } from '@teable/core';
 import { PrismaService } from '@teable/db-main-prisma';
 import { CollaboratorType, ResourceType } from '@teable/openapi';
 import type {
+  IBaseErdVo,
   ICreateBaseFromTemplateRo,
   ICreateBaseRo,
   IDuplicateBaseRo,
@@ -26,6 +27,7 @@ import { getMaxLevelRole } from '../../utils/get-max-level-role';
 import { updateOrder } from '../../utils/update-order';
 import { PermissionService } from '../auth/permission.service';
 import { CollaboratorService } from '../collaborator/collaborator.service';
+import { GraphService } from '../graph/graph.service';
 import { TableOpenApiService } from '../table/open-api/table-open-api.service';
 import { BaseDuplicateService } from './base-duplicate.service';
 
@@ -40,6 +42,7 @@ export class BaseService {
     private readonly baseDuplicateService: BaseDuplicateService,
     private readonly permissionService: PermissionService,
     private readonly tableOpenApiService: TableOpenApiService,
+    private readonly graphService: GraphService,
     @InjectDbProvider() private readonly dbProvider: IDbProvider,
     @ThresholdConfig() private readonly thresholdConfig: IThresholdConfig
   ) {}
@@ -428,5 +431,9 @@ export class BaseService {
       where: { id: baseId },
       data: { spaceId },
     });
+  }
+
+  async generateBaseErd(baseId: string): Promise<IBaseErdVo> {
+    return await this.graphService.generateBaseErd(baseId);
   }
 }

--- a/apps/nestjs-backend/src/features/graph/graph.service.ts
+++ b/apps/nestjs-backend/src/features/graph/graph.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import type { IFieldRo, ILinkFieldOptions, IConvertFieldRo } from '@teable/core';
 import { FieldType, Relationship } from '@teable/core';
+import type { Field, TableMeta } from '@teable/db-main-prisma';
 import { PrismaService } from '@teable/db-main-prisma';
 import type {
   IGraphEdge,
@@ -9,6 +10,8 @@ import type {
   IPlanFieldVo,
   IPlanFieldConvertVo,
   IPlanFieldDeleteVo,
+  IBaseErdTableNode,
+  IBaseErdEdge,
 } from '@teable/openapi';
 import { Knex } from 'knex';
 import { groupBy, keyBy, uniq } from 'lodash';
@@ -451,5 +454,269 @@ export class GraphService {
       updateCellCount,
       estimateTime: this.getEstimateTime(updateCellCount),
     };
+  }
+
+  async generateBaseErd(baseId: string) {
+    const tableRaws = await this.prismaService.tableMeta.findMany({
+      where: {
+        baseId,
+        deletedTime: null,
+      },
+      select: { id: true, name: true, icon: true },
+    });
+
+    const { tableMap, fieldMap, linkFieldRaws, tableNodes } = await this.getBaseErdContext(
+      tableRaws.map((table) => table.id)
+    );
+
+    const { references, referenceFieldRaws } = await this.getBaseErdReference(
+      Object.keys(fieldMap)
+    );
+
+    const {
+      tableNodes: crossTableNodes,
+      tableMap: crossTableTableMap,
+      fieldMap: crossTableFieldMap,
+      linkFieldRaws: crossBaseLinkFieldRaws,
+    } = await this.getBaseErdContext(
+      referenceFieldRaws.filter((field) => !tableMap[field.tableId]).map((field) => field.tableId),
+      true
+    );
+
+    const edges = await this.generateBaseErdEdges({
+      linkFieldRaws,
+      crossBaseLinkFieldRaws,
+      tableMap,
+      fieldMap,
+      crossBaseTableMap: crossTableTableMap,
+      crossBaseFieldMap: crossTableFieldMap,
+      references,
+    });
+
+    return {
+      baseId,
+      nodes: [...tableNodes, ...crossTableNodes],
+      edges,
+    };
+  }
+
+  private async getBaseErdContext(tableIds: string[], crossBase?: boolean) {
+    if (tableIds.length === 0) {
+      return {
+        tableRaws: [],
+        tableMap: {},
+        fieldRaws: [],
+        fieldMap: {},
+        linkFieldRaws: [],
+        tableNodes: [],
+      };
+    }
+    const tableRaws = await this.prismaService.tableMeta.findMany({
+      where: {
+        id: { in: tableIds },
+        deletedTime: null,
+      },
+      select: {
+        id: true,
+        name: true,
+        icon: true,
+        base: crossBase ? { select: { id: true, name: true } } : undefined,
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    });
+    const tableMap = keyBy(tableRaws, 'id');
+
+    const fieldRaws = await this.prismaService.field.findMany({
+      where: {
+        tableId: { in: Object.keys(tableMap) },
+        deletedTime: null,
+      },
+      select: {
+        id: true,
+        tableId: true,
+        name: true,
+        type: true,
+        options: true,
+        isLookup: true,
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    });
+
+    const fieldMap = keyBy(fieldRaws, 'id');
+
+    const linkFieldRaws = fieldRaws
+      .filter((field) => field.type === FieldType.Link && !field.isLookup)
+      .map((field) => {
+        return {
+          ...field,
+          options: field.options && JSON.parse(field.options as string),
+        };
+      });
+
+    const tableId2fieldRaws = groupBy(fieldRaws, 'tableId');
+
+    const tableNodes = tableRaws.map<IBaseErdTableNode>((table) => {
+      const items = tableId2fieldRaws[table.id] ?? [];
+      return {
+        id: table.id,
+        name: table.name,
+        icon: table.icon ?? undefined,
+        crossBaseId: crossBase ? table.base.id : undefined,
+        crossBaseName: crossBase ? table.base.name : undefined,
+        fields: items.map((field) => ({
+          id: field.id,
+          name: field.name,
+          type: field.type as FieldType,
+          isLookup: field.isLookup ?? undefined,
+        })),
+      };
+    });
+
+    return {
+      tableRaws,
+      tableMap,
+      fieldRaws,
+      fieldMap,
+      linkFieldRaws,
+      tableNodes,
+    };
+  }
+
+  private async getBaseErdReference(allFieldIds: string[]) {
+    const references = await this.prismaService.txClient().reference.findMany({
+      where: {
+        OR: [{ fromFieldId: { in: allFieldIds } }, { toFieldId: { in: allFieldIds } }],
+      },
+      select: {
+        fromFieldId: true,
+        toFieldId: true,
+      },
+    });
+
+    const referenceFieldIds = uniq(
+      references.map((ref) => [ref.fromFieldId, ref.toFieldId]).flat()
+    );
+
+    const referenceFieldRaws = await this.prismaService.txClient().field.findMany({
+      where: {
+        id: { in: referenceFieldIds },
+      },
+      select: {
+        id: true,
+        tableId: true,
+      },
+    });
+
+    return {
+      references,
+      referenceFieldRaws,
+    };
+  }
+
+  /**
+   * if A -> B & B -> A, keep A <-> B
+   */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  private async generateBaseErdEdges({
+    linkFieldRaws,
+    tableMap,
+    fieldMap,
+    crossBaseLinkFieldRaws,
+    crossBaseTableMap,
+    crossBaseFieldMap,
+    references,
+  }: {
+    linkFieldRaws: (Pick<Field, 'id' | 'name' | 'type' | 'tableId'> & {
+      options: ILinkFieldOptions;
+    })[];
+    tableMap: Record<string, Pick<TableMeta, 'id' | 'name' | 'icon'>>;
+    fieldMap: Record<string, Pick<Field, 'id' | 'tableId' | 'name' | 'type' | 'isLookup'>>;
+    crossBaseLinkFieldRaws: (Pick<Field, 'id' | 'name' | 'type' | 'tableId'> & {
+      options: ILinkFieldOptions;
+    })[];
+    crossBaseTableMap: Record<string, Pick<TableMeta, 'id' | 'name' | 'icon'>>;
+    crossBaseFieldMap: Record<string, Pick<Field, 'id' | 'tableId' | 'name' | 'type' | 'isLookup'>>;
+    references: { fromFieldId: string; toFieldId: string }[];
+  }) {
+    const fieldEdgeMap = new Map<string, boolean>();
+    const edges: IBaseErdEdge[] = [];
+    for (const field of [...linkFieldRaws, ...crossBaseLinkFieldRaws]) {
+      const { options } = field;
+      const sourceTable =
+        tableMap[options.foreignTableId] ?? crossBaseTableMap[options.foreignTableId];
+      const sourceFieldId = options.symmetricFieldId ?? options.lookupFieldId;
+      const sourceField = fieldMap[sourceFieldId] ?? crossBaseFieldMap[sourceFieldId];
+
+      const targetTable = tableMap[field.tableId] ?? crossBaseTableMap[field.tableId];
+      const targetField = fieldMap[field.id] ?? crossBaseFieldMap[field.id];
+      const edge: IBaseErdEdge = {
+        source: {
+          tableId: sourceTable.id,
+          tableName: sourceTable.name,
+          fieldId: sourceField.id,
+          fieldName: sourceField.name,
+        },
+        target: {
+          tableId: targetTable.id,
+          tableName: targetTable.name,
+          fieldId: targetField.id,
+          fieldName: targetField.name,
+        },
+        relationship: options.relationship,
+        isOneWay: options.isOneWay ?? false,
+        type: field.type as FieldType,
+      };
+      const key = `${sourceField.id}-${targetField.id}`;
+      const reverseKey = `${targetField.id}-${sourceField.id}`;
+      if (fieldEdgeMap.has(reverseKey)) {
+        fieldEdgeMap.set(key, true);
+        continue;
+      }
+      fieldEdgeMap.set(key, false);
+      edges.push(edge);
+    }
+
+    for (const { fromFieldId, toFieldId } of references) {
+      const fromField = fieldMap[fromFieldId] ?? crossBaseFieldMap[fromFieldId];
+      const fromTable = tableMap[fromField.tableId] ?? crossBaseTableMap[fromField.tableId];
+      const toField = fieldMap[toFieldId] ?? crossBaseFieldMap[toFieldId];
+      const toTable = tableMap[toField.tableId] ?? crossBaseTableMap[toField.tableId];
+
+      const key = `${fromField.id}-${toField.id}`;
+      const reverseKey = `${toField.id}-${fromField.id}`;
+      if (fieldEdgeMap.has(key) || fieldEdgeMap.has(reverseKey)) {
+        continue;
+      }
+
+      const edge: IBaseErdEdge = {
+        source: {
+          tableId: fromTable.id,
+          tableName: fromTable.name,
+          fieldId: fromField.id,
+          fieldName: fromField.name,
+        },
+        target: {
+          tableId: toTable.id,
+          tableName: toTable.name,
+          fieldId: toField.id,
+          fieldName: toField.name,
+        },
+        type: toField.isLookup ? 'lookup' : (toField.type as FieldType),
+      };
+      edges.push(edge);
+    }
+
+    return edges.map((edge) => {
+      const key = `${edge.source.fieldId}-${edge.target.fieldId}`;
+      const guessOneWay = fieldEdgeMap.get(key) ?? true;
+      return {
+        ...edge,
+        isOneWay: edge.isOneWay ?? guessOneWay,
+      };
+    });
   }
 }

--- a/apps/nestjs-backend/src/features/graph/graph.service.ts
+++ b/apps/nestjs-backend/src/features/graph/graph.service.ts
@@ -621,15 +621,7 @@ export class GraphService {
    * if A -> B & B -> A, keep A <-> B
    */
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  private async generateBaseErdEdges({
-    linkFieldRaws,
-    tableMap,
-    fieldMap,
-    crossBaseLinkFieldRaws,
-    crossBaseTableMap,
-    crossBaseFieldMap,
-    references,
-  }: {
+  private async generateBaseErdEdges(params: {
     linkFieldRaws: (Pick<Field, 'id' | 'name' | 'type' | 'tableId'> & {
       options: ILinkFieldOptions;
     })[];
@@ -642,6 +634,16 @@ export class GraphService {
     crossBaseFieldMap: Record<string, Pick<Field, 'id' | 'tableId' | 'name' | 'type' | 'isLookup'>>;
     references: { fromFieldId: string; toFieldId: string }[];
   }) {
+    const {
+      linkFieldRaws,
+      tableMap,
+      fieldMap,
+      crossBaseLinkFieldRaws,
+      crossBaseTableMap,
+      crossBaseFieldMap,
+      references,
+    } = params;
+
     const fieldEdgeMap = new Map<string, boolean>();
     const edges: IBaseErdEdge[] = [];
     for (const field of [...linkFieldRaws, ...crossBaseLinkFieldRaws]) {
@@ -653,6 +655,11 @@ export class GraphService {
 
       const targetTable = tableMap[field.tableId] ?? crossBaseTableMap[field.tableId];
       const targetField = fieldMap[field.id] ?? crossBaseFieldMap[field.id];
+
+      if (!sourceTable || !targetTable || !sourceField || !targetField) {
+        continue;
+      }
+
       const edge: IBaseErdEdge = {
         source: {
           tableId: sourceTable.id,

--- a/apps/nestjs-backend/test/base.e2e-spec.ts
+++ b/apps/nestjs-backend/test/base.e2e-spec.ts
@@ -8,6 +8,7 @@ import type {
   UserCollaboratorItem,
 } from '@teable/openapi';
 import {
+  baseErdVoSchema,
   CREATE_BASE,
   CREATE_BASE_INVITATION_LINK,
   CREATE_SPACE,
@@ -23,6 +24,7 @@ import {
   GET_BASE_LIST,
   getBaseAll,
   getBaseCollaboratorList,
+  getBaseErd,
   getUserCollaborators,
   listBaseCollaboratorUserVoSchema,
   listBaseInvitationLink,
@@ -490,5 +492,27 @@ describe('OpenAPI BaseController (e2e)', () => {
 
     expect(res.data.find((v) => v.id === baseId1)).toBeUndefined();
     expect(res.data.find((v) => v.id === baseId2)).toBeDefined();
+  });
+
+  describe('Base ERD', () => {
+    let baseId: string;
+    let spaceId1: string;
+    beforeEach(async () => {
+      spaceId1 = await createSpace({
+        name: 'new space test base erd',
+      }).then((res) => res.id);
+      baseId = await createBase({
+        name: 'new base test base erd',
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+    });
+    afterEach(async () => {
+      await permanentDeleteSpace(spaceId1);
+    });
+    it('/api/base/:baseId/erd (GET)', async () => {
+      const res = await getBaseErd(baseId);
+      expect(baseErdVoSchema.safeParse(res.data).success).toEqual(true);
+      expect(res.data.baseId).toEqual(baseId);
+    });
   });
 });

--- a/apps/nestjs-backend/test/base.e2e-spec.ts
+++ b/apps/nestjs-backend/test/base.e2e-spec.ts
@@ -1,11 +1,13 @@
 import type { INestApplication } from '@nestjs/common';
-import { Role } from '@teable/core';
+import type { ILinkFieldOptions } from '@teable/core';
+import { FieldType, Relationship, Role } from '@teable/core';
 import type {
   ICreateBaseVo,
   ICreateSpaceVo,
   IUserMeVo,
   ListBaseInvitationLinkVo,
   UserCollaboratorItem,
+  IBaseErdEdge,
 } from '@teable/openapi';
 import {
   baseErdVoSchema,
@@ -14,6 +16,7 @@ import {
   CREATE_SPACE,
   createBaseInvitationLink,
   createBaseInvitationLinkVoSchema,
+  createTable,
   DELETE_BASE,
   DELETE_BASE_COLLABORATOR,
   DELETE_SPACE,
@@ -42,6 +45,7 @@ import { createNewUserAxios } from './utils/axios-instance/new-user';
 import { getError } from './utils/get-error';
 import {
   createBase,
+  createField,
   createSpace,
   deleteSpace,
   initApp,
@@ -495,24 +499,198 @@ describe('OpenAPI BaseController (e2e)', () => {
   });
 
   describe('Base ERD', () => {
-    let baseId: string;
     let spaceId1: string;
+
     beforeEach(async () => {
       spaceId1 = await createSpace({
         name: 'new space test base erd',
-      }).then((res) => res.id);
-      baseId = await createBase({
-        name: 'new base test base erd',
-        spaceId: spaceId1,
       }).then((res) => res.id);
     });
     afterEach(async () => {
       await permanentDeleteSpace(spaceId1);
     });
-    it('/api/base/:baseId/erd (GET)', async () => {
-      const res = await getBaseErd(baseId);
-      expect(baseErdVoSchema.safeParse(res.data).success).toEqual(true);
-      expect(res.data.baseId).toEqual(baseId);
+
+    const getRelationReference = (edges: IBaseErdEdge[]) => {
+      return edges
+        .filter((edge) => Boolean(edge.relationship))
+        .map((edge) => {
+          const { source, target } = edge;
+          return `${source.tableId}.${source.fieldId}-${target.tableId}.${target.fieldId}`;
+        })
+        .sort();
+    };
+
+    const getTypeMap = (edges: IBaseErdEdge[]) => {
+      return edges
+        .filter((edge) => !edge.relationship)
+        .reduce(
+          (acc, edge) => {
+            acc[edge.type] = (acc[edge.type] || 0) + 1;
+            return acc;
+          },
+          {} as Record<FieldType | 'lookup', number>
+        );
+    };
+
+    it('/api/base/:baseId/erd (GET) - relationship', async () => {
+      const baseId = await createBase({
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+      const table1 = await createTable(baseId).then((res) => res.data);
+      const table2 = await createTable(baseId).then((res) => res.data);
+
+      await createField(table1.id, {
+        name: 'new link field1',
+        type: FieldType.Link,
+        options: {
+          isOneWay: true,
+          foreignTableId: table2.id,
+          relationship: Relationship.OneOne,
+        },
+      });
+
+      await createField(table1.id, {
+        name: 'new link field2',
+        type: FieldType.Link,
+        options: {
+          isOneWay: true,
+          relationship: Relationship.OneMany,
+          foreignTableId: table2.id,
+        },
+      });
+
+      await createField(table1.id, {
+        name: 'new link field3',
+        type: FieldType.Link,
+        options: {
+          foreignTableId: table2.id,
+          relationship: Relationship.ManyOne,
+        },
+      });
+
+      await createField(table1.id, {
+        name: 'new link field4',
+        type: FieldType.Link,
+        options: {
+          foreignTableId: table2.id,
+          relationship: Relationship.ManyMany,
+        },
+      });
+
+      const data = await getBaseErd(baseId).then((res) => res.data);
+      expect(baseErdVoSchema.safeParse(data).success).toEqual(true);
+      expect(data.baseId).toEqual(baseId);
+      expect(getRelationReference(data.edges).length).toEqual(4);
+    });
+
+    it('/api/base/:baseId/erd (GET) - reference(formula, lookup, rollup, link)', async () => {
+      const baseId = await createBase({
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+      const table1 = await createTable(baseId).then((res) => res.data);
+      const table2 = await createTable(baseId).then((res) => res.data);
+
+      const textField = table1.fields[0];
+      const linkField = await createField(table1.id, {
+        type: FieldType.Link,
+        options: {
+          foreignTableId: table2.id,
+          relationship: Relationship.OneOne,
+        },
+      });
+
+      const lookupField = await createField(table1.id, {
+        type: FieldType.SingleLineText,
+        isLookup: true,
+        lookupOptions: {
+          foreignTableId: table2.id,
+          lookupFieldId: table2.fields[0].id,
+          linkFieldId: linkField.id,
+        },
+      });
+
+      await createField(table1.id, {
+        type: FieldType.Rollup,
+        options: {
+          expression: 'countall({values})',
+        },
+        lookupOptions: {
+          foreignTableId: table2.id,
+          lookupFieldId: table2.fields[0].id,
+          linkFieldId: linkField.id,
+        },
+      });
+
+      await createField(table1.id, {
+        type: FieldType.Formula,
+        options: {
+          expression: `{${textField.id}}`,
+        },
+      });
+
+      await createField(table1.id, {
+        type: FieldType.Formula,
+        options: {
+          expression: `{${lookupField.id}}`,
+        },
+      });
+
+      const data = await getBaseErd(baseId).then((res) => res.data);
+      expect(baseErdVoSchema.safeParse(data).success).toEqual(true);
+      expect(data.baseId).toEqual(baseId);
+      expect(getRelationReference(data.edges).length).toEqual(1);
+      const typeMap = getTypeMap(data.edges);
+      expect(typeMap).toEqual({
+        formula: 2,
+        link: (linkField.options as ILinkFieldOptions).isOneWay ? 1 : 2,
+        lookup: 1,
+        rollup: 1,
+      });
+    });
+
+    it('/api/base/:baseId/erd (GET) - cross base', async () => {
+      const baseId1 = await createBase({
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+      const base1Table1 = await createTable(baseId1).then((res) => res.data);
+
+      const baseId2 = await createBase({
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+      const base2Table1 = await createTable(baseId2).then((res) => res.data);
+
+      await createField(base1Table1.id, {
+        type: FieldType.Link,
+        options: {
+          baseId: baseId2,
+          foreignTableId: base2Table1.id,
+          relationship: Relationship.OneOne,
+        },
+      });
+
+      const baseId3 = await createBase({
+        spaceId: spaceId1,
+      }).then((res) => res.id);
+      const base3Table1 = await createTable(baseId3).then((res) => res.data);
+
+      await createField(base2Table1.id, {
+        type: FieldType.Link,
+        options: {
+          baseId: baseId3,
+          foreignTableId: base3Table1.id,
+          relationship: Relationship.OneOne,
+        },
+      });
+
+      const base1Erd = await getBaseErd(baseId1).then((res) => res.data);
+      expect(baseErdVoSchema.safeParse(base1Erd).success).toEqual(true);
+      expect(base1Erd.baseId).toEqual(baseId1);
+      expect(getRelationReference(base1Erd.edges).length).toEqual(1);
+
+      const base2Erd = await getBaseErd(baseId2).then((res) => res.data);
+      expect(baseErdVoSchema.safeParse(base2Erd).success).toEqual(true);
+      expect(base2Erd.baseId).toEqual(baseId2);
+      expect(getRelationReference(base2Erd.edges).length).toEqual(2);
     });
   });
 });

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -175,6 +175,7 @@
     "react-syntax-highlighter": "15.5.0",
     "react-textarea-autosize": "8.5.3",
     "react-use": "17.5.1",
+    "reactflow": "11.11.1",
     "react-virtuoso": "4.7.10",
     "recharts": "2.12.3",
     "reconnecting-websocket": "4.4.0",

--- a/apps/nextjs-app/src/features/app/blocks/design/TableTabs.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/design/TableTabs.tsx
@@ -21,7 +21,7 @@ const BaseErdialog = ({ baseId }: { baseId: string }) => {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">ER</Button>
+        <Button variant="outline">ERD</Button>
       </DialogTrigger>
       <DialogContent
         className="flex max-w-7xl p-0"

--- a/apps/nextjs-app/src/features/app/blocks/design/TableTabs.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/design/TableTabs.tsx
@@ -2,12 +2,36 @@ import { Table2 } from '@teable/icons';
 import { AnchorContext, FieldProvider, TablePermissionProvider } from '@teable/sdk/context';
 import { useTables } from '@teable/sdk/hooks';
 import { Selector } from '@teable/ui-lib/base';
-import { Tabs, TabsContent } from '@teable/ui-lib/shadcn';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  Tabs,
+  TabsContent,
+} from '@teable/ui-lib/shadcn';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
+import { DynamicBaseErd } from '../erd/DynamicBaseErd';
 import { FieldSetting } from '../view/field/FieldSetting';
 import { DataTable } from './data-table/DataTable';
 import { TableDetail } from './TableDetail';
+
+const BaseErdialog = ({ baseId }: { baseId: string }) => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">ER</Button>
+      </DialogTrigger>
+      <DialogContent
+        className="flex max-w-7xl p-0"
+        style={{ width: 'calc(100% - 40px)', height: 'calc(100% - 100px)' }}
+      >
+        <DynamicBaseErd baseId={baseId} />
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 const TablePicker = ({
   tableId,
@@ -58,7 +82,7 @@ export const TableTabs = () => {
       }
       className="space-y-4"
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
         <TablePicker
           tableId={tableId}
           readonly={false}
@@ -66,6 +90,7 @@ export const TableTabs = () => {
             router.push({ pathname: router.pathname, query: { ...router.query, tableId } })
           }
         />
+        <BaseErdialog baseId={baseId} />
       </div>
 
       {tables.map((table) => (

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -183,7 +183,7 @@ export const BaseErd = (props: { baseId: string }) => {
       onEdgesChange={onEdgesChange}
       fitView
       minZoom={0.25}
-      maxZoom={1.5}
+      maxZoom={1.25}
     >
       <CustomMarkers baseId={baseId} />
       <Background variant={BackgroundVariant.Dots} className="bg-secondary" />

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -167,7 +167,7 @@ export const BaseErd = (props: { baseId: string }) => {
 
   const allEdgeTypes = useMemo(() => {
     const { edges = [] } = baseErd ?? {};
-    return uniq(edges.map((edge) => edge.type))
+    return uniq(edges.filter((edge) => !edge.relationship).map((edge) => edge.type))
       .sort()
       .map((type) => getEdgeTypeInfo(type));
   }, [baseErd, getEdgeTypeInfo]);
@@ -212,29 +212,14 @@ export const BaseErd = (props: { baseId: string }) => {
         }}
       />
       <div className="absolute right-10 top-10 z-10 flex ">
-        {allEdgeTypes.length === 1 && (
-          <div className="w-min-content flex items-center gap-2 p-2">
-            <Switch
-              checked={showEdgeTypes.includes(allEdgeTypes[0].type)}
-              onCheckedChange={(checked) => {
-                setShowEdgeTypes((prev) =>
-                  checked
-                    ? [...prev, allEdgeTypes[0].type]
-                    : prev.filter((t) => t !== allEdgeTypes[0].type)
-                );
-              }}
-            />
-            <Label>{allEdgeTypes[0].title}</Label>
-          </div>
-        )}
-        {allEdgeTypes.length > 1 && (
+        {allEdgeTypes.length > 0 && (
           <Popover modal>
             <PopoverTrigger asChild>
-              <Button variant="outline" className="flex items-center gap-2">
+              <Button variant="outline" size="icon" className="flex items-center gap-2">
                 <FilterIcon className="size-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-fit p-0">
+            <PopoverContent className="w-fit min-w-24 p-0">
               {allEdgeTypes.map(({ type, title }) => (
                 <div key={type} className="w-min-content flex items-center gap-2 p-2">
                   <Switch

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -20,6 +20,7 @@ import {
 } from 'reactflow';
 import { tableConfig } from '@/features/i18n/table.config';
 import { BaseErdTableNode } from './BaseErdTableNode';
+import { SelfConnectingEdge } from './SelfConnectingEdge';
 
 const openTable = (baseId: string, tableId: string) => {
   const url = new URL(`/base/${baseId}/${tableId}`, window.location.origin);
@@ -110,8 +111,8 @@ const buildEdges = (
       const relationshipLabel = edge.relationship ? translationMap[edge.relationship] : '';
       // `[${source.tableName}]${source.fieldName} - ${relationshipLabel} - [${target.tableName}]${target.fieldName}`
 
-      // const { start, end } = getMarkerId(baseId, edge.relationship ?? Relationship.OneOne);
-
+      const { start, end } = getMarkerId(baseId, edge.relationship ?? Relationship.OneOne);
+      const isSelfConnecting = source.tableId === target.tableId;
       const { title } =
         edge.type === 'lookup'
           ? { title: translationMap['lookup'] }
@@ -122,6 +123,7 @@ const buildEdges = (
             });
       return {
         id: `${source.tableId}-${source.fieldId}-${target.tableId}-${target.fieldId}`,
+        type: isSelfConnecting ? 'selfConnecting' : 'default',
         source: source.tableId,
         target: target.tableId,
         sourceHandle: source.fieldId,
@@ -129,14 +131,14 @@ const buildEdges = (
         style: { strokeWidth: 1 },
         label: relationshipLabel ? relationshipLabel : title,
         data: {},
-        markerStart,
-        markerEnd,
+        markerStart: markerStart,
+        markerEnd: markerEnd,
       };
     });
 };
 
 // todo: custom markers for edges
-const ERMarkers = ({ baseId }: { baseId: string }) => {
+const CustomMarkers = ({ baseId }: { baseId: string }) => {
   return (
     <svg style={{ position: 'absolute', top: 0, left: 0 }}>
       <defs>
@@ -183,7 +185,9 @@ const connectionLineStyle = { stroke: '#fff' };
 const nodeTypes = {
   tableNode: BaseErdTableNode,
 };
-const edgeTypes = {};
+const edgeTypes = {
+  selfConnecting: SelfConnectingEdge,
+};
 
 export const BaseErd = (props: { baseId: string }) => {
   const { baseId } = props;
@@ -223,7 +227,7 @@ export const BaseErd = (props: { baseId: string }) => {
 
   return (
     <>
-      <ERMarkers baseId={baseId} />
+      <CustomMarkers baseId={baseId} />
 
       <ReactFlow
         nodes={nodes}

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -1,0 +1,273 @@
+import { Relationship } from '@teable/core';
+import {
+  getBaseErd,
+  type IBaseErdVo,
+  type IBaseErdEdge,
+  type IBaseErdTableNode,
+} from '@teable/openapi';
+import { useFieldStaticGetter } from '@teable/sdk/hooks';
+import { Label, Switch } from '@teable/ui-lib/shadcn';
+import { useTranslation } from 'next-i18next';
+import { useState, useEffect, useMemo } from 'react';
+import {
+  ReactFlow,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  Background,
+  BackgroundVariant,
+  MarkerType,
+} from 'reactflow';
+import { tableConfig } from '@/features/i18n/table.config';
+import { BaseErdTableNode } from './BaseErdTableNode';
+
+const openTable = (baseId: string, tableId: string) => {
+  const url = new URL(`/base/${baseId}/${tableId}`, window.location.origin);
+  window.open(url.toString(), '_blank');
+};
+
+const buildMarkerId = (baseId: string) => {
+  return {
+    one: `${baseId}-one`,
+    many: `${baseId}-many`,
+  };
+};
+
+const getMarkerId = (baseId: string, relationship: Relationship) => {
+  const { one, many } = buildMarkerId(baseId);
+  const start =
+    relationship === Relationship.OneOne || relationship === Relationship.OneMany ? one : many;
+  const end =
+    relationship === Relationship.OneOne || relationship === Relationship.ManyOne ? one : many;
+  return {
+    start,
+    end,
+  };
+};
+
+const buildNodes = (
+  baseId: string,
+  nodes: IBaseErdTableNode[],
+  fieldStaticGetter: ReturnType<typeof useFieldStaticGetter>,
+  openTable: (baseId: string, tableId: string) => void
+) => {
+  const col = Math.ceil(Math.sqrt(nodes.length));
+  const yMap: Record<number, { rowIndex: number; height: number }> = {};
+  const resultNodes = [];
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const colIndex = i % col;
+    const x = colIndex * 300;
+    const y = yMap[colIndex]?.height ?? 0;
+    resultNodes.push({
+      id: node.id,
+      type: 'tableNode',
+      data: {
+        ...node,
+        baseId,
+        fieldStaticGetter,
+        openTable,
+      },
+      position: { x, y },
+    });
+    const rowIndex = yMap[colIndex]?.rowIndex ?? 0;
+    const height = node.fields.length * 24 + (node.fields.length - 1) * 8 + 100;
+    yMap[colIndex] = {
+      rowIndex: rowIndex + 1,
+      height: y + height,
+    };
+  }
+  return resultNodes;
+};
+
+const buildEdges = (
+  baseId: string,
+  edges: IBaseErdEdge[],
+  translationMap: Record<string, string>,
+  fieldStaticGetter: ReturnType<typeof useFieldStaticGetter>,
+  showAllRelations: boolean
+) => {
+  return edges
+    .filter((edge) => {
+      return showAllRelations || Boolean(edge.relationship);
+    })
+    .map((edge) => {
+      const markerStart = !edge.isOneWay
+        ? {
+            type: MarkerType.ArrowClosed,
+            orient: 'auto-start-reverse',
+            width: 16,
+            height: 16,
+          }
+        : undefined;
+      const markerEnd = {
+        type: MarkerType.ArrowClosed,
+        width: 16,
+        height: 16,
+      };
+      const { source, target } = edge;
+
+      const relationshipLabel = edge.relationship ? translationMap[edge.relationship] : '';
+      // `[${source.tableName}]${source.fieldName} - ${relationshipLabel} - [${target.tableName}]${target.fieldName}`
+
+      // const { start, end } = getMarkerId(baseId, edge.relationship ?? Relationship.OneOne);
+
+      const { title } =
+        edge.type === 'lookup'
+          ? { title: translationMap['lookup'] }
+          : fieldStaticGetter(edge.type, {
+              isLookup: false,
+              hasAiConfig: false,
+              deniedReadRecord: false,
+            });
+      return {
+        id: `${source.tableId}-${source.fieldId}-${target.tableId}-${target.fieldId}`,
+        source: source.tableId,
+        target: target.tableId,
+        sourceHandle: source.fieldId,
+        targetHandle: target.fieldId,
+        style: { strokeWidth: 1 },
+        label: relationshipLabel ? relationshipLabel : title,
+        data: {},
+        markerStart,
+        markerEnd,
+      };
+    });
+};
+
+// todo: custom markers for edges
+const ERMarkers = ({ baseId }: { baseId: string }) => {
+  return (
+    <svg style={{ position: 'absolute', top: 0, left: 0 }}>
+      <defs>
+        <marker
+          id={buildMarkerId(baseId).one}
+          markerWidth="16"
+          markerHeight="16"
+          viewBox="-10 -10 20 20"
+          markerUnits="strokeWidth"
+          orient="auto-start-reverse"
+          refX="0"
+          refY="0"
+        >
+          <polyline
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            points="-5,-4 0,0 -5,4 -5,-4"
+            style={{ stroke: 'rgb(177, 177, 183)', fill: 'rgb(177, 177, 183)', strokeWidth: 1 }}
+          ></polyline>
+        </marker>
+        <marker
+          id={buildMarkerId(baseId).many}
+          markerWidth="16"
+          markerHeight="16"
+          viewBox="-10 -10 20 20"
+          markerUnits="strokeWidth"
+          orient="auto-start-reverse"
+          refX="0"
+          refY="0"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            r="8"
+            style={{ stroke: 'rgb(177, 177, 183)', fill: 'rgb(177, 177, 183)', strokeWidth: 1 }}
+          ></circle>
+        </marker>
+      </defs>
+    </svg>
+  );
+};
+
+const connectionLineStyle = { stroke: '#fff' };
+const nodeTypes = {
+  tableNode: BaseErdTableNode,
+};
+const edgeTypes = {};
+
+export const BaseErd = (props: { baseId: string }) => {
+  const { baseId } = props;
+  const { t } = useTranslation(tableConfig.i18nNamespaces);
+  const fieldStaticGetter = useFieldStaticGetter();
+  const [showAllRelations, setShowAllRelations] = useState(false);
+  const [baseErd, setBaseErd] = useState<IBaseErdVo | null>(null);
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+  const translationMap = useMemo(() => {
+    return {
+      [Relationship.OneOne]: t('table:field.editor.oneToOne'),
+      [Relationship.OneMany]: t('table:field.editor.oneToMany'),
+      [Relationship.ManyOne]: t('table:field.editor.manyToOne'),
+      [Relationship.ManyMany]: t('table:field.editor.manyToMany'),
+      lookup: t('sdk:field.title.lookup'),
+    };
+  }, [t]);
+
+  useEffect(() => {
+    getBaseErd(baseId).then((baseErd) => {
+      setBaseErd(baseErd.data);
+    });
+  }, [baseId]);
+
+  useEffect(() => {
+    if (baseErd) {
+      const { baseId, nodes, edges } = baseErd;
+      setNodes(buildNodes(baseId, nodes, fieldStaticGetter, openTable));
+      setEdges(buildEdges(baseId, edges, translationMap, fieldStaticGetter, showAllRelations));
+    } else {
+      setNodes([]);
+      setEdges([]);
+    }
+  }, [baseErd, showAllRelations, translationMap, fieldStaticGetter, setNodes, setEdges]);
+
+  return (
+    <>
+      <ERMarkers baseId={baseId} />
+
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        connectionLineStyle={connectionLineStyle}
+        fitView
+        minZoom={0.25}
+        maxZoom={1}
+        // onEdgeMouseEnter={(event, edge) => {
+        //   setEdges((prev) => {
+        //     return prev.map((e) => {
+        //       if (e.id === edge.id) {
+        //         return { ...e, style: { ...e.style, strokeWidth: 1.5 }, label: e.data.label };
+        //       }
+        //       return e;
+        //     });
+        //   });
+        // }}
+        // onEdgeMouseLeave={(event, edge) => {
+        //   setEdges((prev) => {
+        //     return prev.map((e) => {
+        //       return { ...e, style: { ...e.style, strokeWidth: 1 }, label: '' };
+        //     });
+        //   });
+        // }}
+      >
+        <Background variant={BackgroundVariant.Dots} className="bg-secondary" />
+        <Controls
+          className="Controls"
+          fitViewOptions={{
+            duration: 500,
+          }}
+        />
+        <div className="absolute right-10 top-10 z-10 flex items-center gap-2">
+          <div className="flex items-center gap-2">
+            <Switch checked={showAllRelations} onCheckedChange={setShowAllRelations} />
+            <Label>Show All Relations</Label>
+          </div>
+        </div>
+      </ReactFlow>
+    </>
+  );
+};

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -20,30 +20,12 @@ import {
 } from 'reactflow';
 import { tableConfig } from '@/features/i18n/table.config';
 import { BaseErdTableNode } from './BaseErdTableNode';
+import { CustomMarkers, getMarker } from './CustomMakers';
 import { SelfConnectingEdge } from './SelfConnectingEdge';
 
 const openTable = (baseId: string, tableId: string) => {
   const url = new URL(`/base/${baseId}/${tableId}`, window.location.origin);
   window.open(url.toString(), '_blank');
-};
-
-const buildMarkerId = (baseId: string) => {
-  return {
-    one: `${baseId}-one`,
-    many: `${baseId}-many`,
-  };
-};
-
-const getMarkerId = (baseId: string, relationship: Relationship) => {
-  const { one, many } = buildMarkerId(baseId);
-  const start =
-    relationship === Relationship.OneOne || relationship === Relationship.OneMany ? one : many;
-  const end =
-    relationship === Relationship.OneOne || relationship === Relationship.ManyOne ? one : many;
-  return {
-    start,
-    end,
-  };
 };
 
 const buildNodes = (
@@ -93,7 +75,12 @@ const buildEdges = (
       return showAllRelations || Boolean(edge.relationship);
     })
     .map((edge) => {
-      const markerStart = !edge.isOneWay
+      const { source, target } = edge;
+
+      const relationshipLabel = edge.relationship ? translationMap[edge.relationship] : '';
+      // `[${source.tableName}]${source.fieldName} - ${relationshipLabel} - [${target.tableName}]${target.fieldName}`
+
+      const defaultMarkerStart = !edge.isOneWay
         ? {
             type: MarkerType.ArrowClosed,
             orient: 'auto-start-reverse',
@@ -101,17 +88,15 @@ const buildEdges = (
             height: 16,
           }
         : undefined;
-      const markerEnd = {
+      const defaultMarkerEnd = {
         type: MarkerType.ArrowClosed,
         width: 16,
         height: 16,
       };
-      const { source, target } = edge;
+      const { start: markerStart, end: markerEnd } = edge.relationship
+        ? getMarker(baseId, edge.relationship)
+        : { start: defaultMarkerStart, end: defaultMarkerEnd };
 
-      const relationshipLabel = edge.relationship ? translationMap[edge.relationship] : '';
-      // `[${source.tableName}]${source.fieldName} - ${relationshipLabel} - [${target.tableName}]${target.fieldName}`
-
-      const { start, end } = getMarkerId(baseId, edge.relationship ?? Relationship.OneOne);
       const isSelfConnecting = source.tableId === target.tableId;
       const { title } =
         edge.type === 'lookup'
@@ -130,55 +115,10 @@ const buildEdges = (
         targetHandle: target.fieldId,
         style: { strokeWidth: 1 },
         label: relationshipLabel ? relationshipLabel : title,
-        data: {},
-        markerStart: markerStart,
-        markerEnd: markerEnd,
+        markerStart,
+        markerEnd,
       };
     });
-};
-
-// todo: custom markers for edges
-const CustomMarkers = ({ baseId }: { baseId: string }) => {
-  return (
-    <svg style={{ position: 'absolute', top: 0, left: 0 }}>
-      <defs>
-        <marker
-          id={buildMarkerId(baseId).one}
-          markerWidth="16"
-          markerHeight="16"
-          viewBox="-10 -10 20 20"
-          markerUnits="strokeWidth"
-          orient="auto-start-reverse"
-          refX="0"
-          refY="0"
-        >
-          <polyline
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            points="-5,-4 0,0 -5,4 -5,-4"
-            style={{ stroke: 'rgb(177, 177, 183)', fill: 'rgb(177, 177, 183)', strokeWidth: 1 }}
-          ></polyline>
-        </marker>
-        <marker
-          id={buildMarkerId(baseId).many}
-          markerWidth="16"
-          markerHeight="16"
-          viewBox="-10 -10 20 20"
-          markerUnits="strokeWidth"
-          orient="auto-start-reverse"
-          refX="0"
-          refY="0"
-        >
-          <circle
-            cx="8"
-            cy="8"
-            r="8"
-            style={{ stroke: 'rgb(177, 177, 183)', fill: 'rgb(177, 177, 183)', strokeWidth: 1 }}
-          ></circle>
-        </marker>
-      </defs>
-    </svg>
-  );
 };
 
 const connectionLineStyle = { stroke: '#fff' };
@@ -195,7 +135,7 @@ export const BaseErd = (props: { baseId: string }) => {
   const fieldStaticGetter = useFieldStaticGetter();
   const [showAllRelations, setShowAllRelations] = useState(false);
   const [baseErd, setBaseErd] = useState<IBaseErdVo | null>(null);
-  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<IBaseErdTableNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const translationMap = useMemo(() => {
@@ -216,62 +156,49 @@ export const BaseErd = (props: { baseId: string }) => {
 
   useEffect(() => {
     if (baseErd) {
-      const { baseId, nodes, edges } = baseErd;
+      const { baseId, nodes } = baseErd;
       setNodes(buildNodes(baseId, nodes, fieldStaticGetter, openTable));
-      setEdges(buildEdges(baseId, edges, translationMap, fieldStaticGetter, showAllRelations));
     } else {
       setNodes([]);
+    }
+  }, [baseErd, fieldStaticGetter, setNodes]);
+
+  useEffect(() => {
+    if (baseErd) {
+      const { baseId, edges } = baseErd;
+      setEdges(buildEdges(baseId, edges, translationMap, fieldStaticGetter, showAllRelations));
+    } else {
       setEdges([]);
     }
-  }, [baseErd, showAllRelations, translationMap, fieldStaticGetter, setNodes, setEdges]);
+  }, [baseErd, showAllRelations, translationMap, fieldStaticGetter, setEdges]);
 
   return (
-    <>
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
+      connectionLineStyle={connectionLineStyle}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      fitView
+      minZoom={0.25}
+      maxZoom={1.5}
+    >
       <CustomMarkers baseId={baseId} />
-
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        connectionLineStyle={connectionLineStyle}
-        fitView
-        minZoom={0.25}
-        maxZoom={1}
-        // onEdgeMouseEnter={(event, edge) => {
-        //   setEdges((prev) => {
-        //     return prev.map((e) => {
-        //       if (e.id === edge.id) {
-        //         return { ...e, style: { ...e.style, strokeWidth: 1.5 }, label: e.data.label };
-        //       }
-        //       return e;
-        //     });
-        //   });
-        // }}
-        // onEdgeMouseLeave={(event, edge) => {
-        //   setEdges((prev) => {
-        //     return prev.map((e) => {
-        //       return { ...e, style: { ...e.style, strokeWidth: 1 }, label: '' };
-        //     });
-        //   });
-        // }}
-      >
-        <Background variant={BackgroundVariant.Dots} className="bg-secondary" />
-        <Controls
-          className="Controls"
-          fitViewOptions={{
-            duration: 500,
-          }}
-        />
-        <div className="absolute right-10 top-10 z-10 flex items-center gap-2">
-          <div className="flex items-center gap-2">
-            <Switch checked={showAllRelations} onCheckedChange={setShowAllRelations} />
-            <Label>Show All Relations</Label>
-          </div>
+      <Background variant={BackgroundVariant.Dots} className="bg-secondary" />
+      <Controls
+        className="Controls"
+        fitViewOptions={{
+          duration: 500,
+        }}
+      />
+      <div className="absolute right-10 top-10 z-10 flex items-center gap-2">
+        <div className="flex items-center gap-2">
+          <Switch checked={showAllRelations} onCheckedChange={setShowAllRelations} />
+          <Label>Show All Relations</Label>
         </div>
-      </ReactFlow>
-    </>
+      </div>
+    </ReactFlow>
   );
 };

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErd.tsx
@@ -1,14 +1,19 @@
 import { Relationship } from '@teable/core';
-import {
-  getBaseErd,
-  type IBaseErdVo,
-  type IBaseErdEdge,
-  type IBaseErdTableNode,
-} from '@teable/openapi';
+import { getBaseErd } from '@teable/openapi';
+import type { IBaseErdEdge, IBaseErdVo, IBaseErdTableNode } from '@teable/openapi';
 import { useFieldStaticGetter } from '@teable/sdk/hooks';
-import { Label, Switch } from '@teable/ui-lib/shadcn';
+import {
+  Button,
+  Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Switch,
+} from '@teable/ui-lib/shadcn';
+import { uniq } from 'lodash';
+import { FilterIcon } from 'lucide-react';
 import { useTranslation } from 'next-i18next';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   ReactFlow,
   Controls,
@@ -54,7 +59,8 @@ const buildNodes = (
       position: { x, y },
     });
     const rowIndex = yMap[colIndex]?.rowIndex ?? 0;
-    const height = node.fields.length * 24 + (node.fields.length - 1) * 8 + 100;
+    // 24(h6) is the height of a field, 8(gap-2) is the gap between fields, 100 is the gap between tables
+    const height = node.fields.length * 24 + (node.fields.length + 1) * 8 + 100;
     yMap[colIndex] = {
       rowIndex: rowIndex + 1,
       height: y + height,
@@ -66,28 +72,23 @@ const buildNodes = (
 const buildEdges = (
   baseId: string,
   edges: IBaseErdEdge[],
+  showEdgeTypes: IBaseErdEdge['type'][],
   translationMap: Record<string, string>,
-  fieldStaticGetter: ReturnType<typeof useFieldStaticGetter>,
-  showAllRelations: boolean
+  getEdgeTypeInfo: (type: IBaseErdEdge['type']) => { title: string }
 ) => {
   return edges
     .filter((edge) => {
-      return showAllRelations || Boolean(edge.relationship);
+      return Boolean(edge.relationship) || showEdgeTypes.includes(edge.type);
     })
     .map((edge) => {
       const { source, target } = edge;
 
-      const relationshipLabel = edge.relationship ? translationMap[edge.relationship] : '';
+      const wayLabel = edge.isOneWay ? translationMap['oneWay'] : translationMap['twoWay'];
+      const relationshipLabel = edge.relationship
+        ? `${translationMap[edge.relationship]}(${wayLabel})`
+        : '';
       // `[${source.tableName}]${source.fieldName} - ${relationshipLabel} - [${target.tableName}]${target.fieldName}`
 
-      const defaultMarkerStart = !edge.isOneWay
-        ? {
-            type: MarkerType.ArrowClosed,
-            orient: 'auto-start-reverse',
-            width: 16,
-            height: 16,
-          }
-        : undefined;
       const defaultMarkerEnd = {
         type: MarkerType.ArrowClosed,
         width: 16,
@@ -95,17 +96,10 @@ const buildEdges = (
       };
       const { start: markerStart, end: markerEnd } = edge.relationship
         ? getMarker(baseId, edge.relationship)
-        : { start: defaultMarkerStart, end: defaultMarkerEnd };
+        : { start: undefined, end: defaultMarkerEnd };
 
       const isSelfConnecting = source.tableId === target.tableId;
-      const { title } =
-        edge.type === 'lookup'
-          ? { title: translationMap['lookup'] }
-          : fieldStaticGetter(edge.type, {
-              isLookup: false,
-              hasAiConfig: false,
-              deniedReadRecord: false,
-            });
+      const { title } = getEdgeTypeInfo(edge.type);
       return {
         id: `${source.tableId}-${source.fieldId}-${target.tableId}-${target.fieldId}`,
         type: isSelfConnecting ? 'selfConnecting' : 'default',
@@ -133,7 +127,7 @@ export const BaseErd = (props: { baseId: string }) => {
   const { baseId } = props;
   const { t } = useTranslation(tableConfig.i18nNamespaces);
   const fieldStaticGetter = useFieldStaticGetter();
-  const [showAllRelations, setShowAllRelations] = useState(false);
+  const [showEdgeTypes, setShowEdgeTypes] = useState<IBaseErdEdge['type'][]>([]);
   const [baseErd, setBaseErd] = useState<IBaseErdVo | null>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState<IBaseErdTableNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -145,6 +139,8 @@ export const BaseErd = (props: { baseId: string }) => {
       [Relationship.ManyOne]: t('table:field.editor.manyToOne'),
       [Relationship.ManyMany]: t('table:field.editor.manyToMany'),
       lookup: t('sdk:field.title.lookup'),
+      oneWay: t('sdk:field.link.oneWay'),
+      twoWay: t('sdk:field.link.twoWay'),
     };
   }, [t]);
 
@@ -153,6 +149,28 @@ export const BaseErd = (props: { baseId: string }) => {
       setBaseErd(baseErd.data);
     });
   }, [baseId]);
+
+  const getEdgeTypeInfo = useCallback(
+    (type: IBaseErdEdge['type']) => {
+      const { title } =
+        type === 'lookup'
+          ? { title: translationMap['lookup'] }
+          : fieldStaticGetter(type, {
+              isLookup: false,
+              hasAiConfig: false,
+              deniedReadRecord: false,
+            });
+      return { type, title };
+    },
+    [translationMap, fieldStaticGetter]
+  );
+
+  const allEdgeTypes = useMemo(() => {
+    const { edges = [] } = baseErd ?? {};
+    return uniq(edges.map((edge) => edge.type))
+      .sort()
+      .map((type) => getEdgeTypeInfo(type));
+  }, [baseErd, getEdgeTypeInfo]);
 
   useEffect(() => {
     if (baseErd) {
@@ -166,11 +184,11 @@ export const BaseErd = (props: { baseId: string }) => {
   useEffect(() => {
     if (baseErd) {
       const { baseId, edges } = baseErd;
-      setEdges(buildEdges(baseId, edges, translationMap, fieldStaticGetter, showAllRelations));
+      setEdges(buildEdges(baseId, edges, showEdgeTypes, translationMap, getEdgeTypeInfo));
     } else {
       setEdges([]);
     }
-  }, [baseErd, showAllRelations, translationMap, fieldStaticGetter, setEdges]);
+  }, [baseErd, translationMap, setEdges, showEdgeTypes, getEdgeTypeInfo]);
 
   return (
     <ReactFlow
@@ -193,11 +211,46 @@ export const BaseErd = (props: { baseId: string }) => {
           duration: 500,
         }}
       />
-      <div className="absolute right-10 top-10 z-10 flex items-center gap-2">
-        <div className="flex items-center gap-2">
-          <Switch checked={showAllRelations} onCheckedChange={setShowAllRelations} />
-          <Label>Show All Relations</Label>
-        </div>
+      <div className="absolute right-10 top-10 z-10 flex ">
+        {allEdgeTypes.length === 1 && (
+          <div className="w-min-content flex items-center gap-2 p-2">
+            <Switch
+              checked={showEdgeTypes.includes(allEdgeTypes[0].type)}
+              onCheckedChange={(checked) => {
+                setShowEdgeTypes((prev) =>
+                  checked
+                    ? [...prev, allEdgeTypes[0].type]
+                    : prev.filter((t) => t !== allEdgeTypes[0].type)
+                );
+              }}
+            />
+            <Label>{allEdgeTypes[0].title}</Label>
+          </div>
+        )}
+        {allEdgeTypes.length > 1 && (
+          <Popover modal>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="flex items-center gap-2">
+                <FilterIcon className="size-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-fit p-0">
+              {allEdgeTypes.map(({ type, title }) => (
+                <div key={type} className="w-min-content flex items-center gap-2 p-2">
+                  <Switch
+                    checked={showEdgeTypes.includes(type)}
+                    onCheckedChange={(checked) => {
+                      setShowEdgeTypes((prev) =>
+                        checked ? [...prev, type] : prev.filter((t) => t !== type)
+                      );
+                    }}
+                  />
+                  <Label>{title}</Label>
+                </div>
+              ))}
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     </ReactFlow>
   );

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErdTableNode.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErdTableNode.tsx
@@ -1,0 +1,82 @@
+import { Table2 } from '@teable/icons';
+import type { IBaseErdTableNode } from '@teable/openapi';
+import type { useFieldStaticGetter } from '@teable/sdk/hooks';
+import { memo } from 'react';
+import type { NodeProps } from 'reactflow';
+import { Handle, Position } from 'reactflow';
+import { Emoji } from '../../components/emoji/Emoji';
+
+interface IBaseErdTableNodeProps extends IBaseErdTableNode {
+  baseId: string;
+  fieldStaticGetter: ReturnType<typeof useFieldStaticGetter>;
+  openTable: (baseId: string, tableId: string) => void;
+}
+
+export const BaseErdTableNode = memo(({ data }: NodeProps<IBaseErdTableNodeProps>) => {
+  const {
+    id: tableId,
+    name,
+    fields,
+    fieldStaticGetter,
+    icon,
+    crossBaseId,
+    crossBaseName,
+    openTable,
+    baseId,
+  } = data;
+
+  const title = crossBaseName ? `${name}(${crossBaseName})` : name;
+  const fieldComponents = fields.map((field) => {
+    const { Icon } = fieldStaticGetter(field.type, {
+      isLookup: field.isLookup,
+      hasAiConfig: false,
+      deniedReadRecord: false,
+    });
+
+    return (
+      <div key={field.id} className="relative flex h-6 w-full items-center">
+        <div className="flex w-full items-center gap-2 p-2">
+          <Icon className="size-4 shrink-0" />
+          <span className=" truncate" title={field.name}>
+            {field.name}
+          </span>
+        </div>
+        <Handle
+          id={field.id}
+          type="source"
+          position={Position.Right}
+          isConnectable={false}
+          className="opacity-0"
+        />
+        <Handle
+          id={field.id}
+          type="target"
+          position={Position.Left}
+          isConnectable={false}
+          className="opacity-0"
+        />
+      </div>
+    );
+  });
+
+  return (
+    <div key={tableId} className="min-w-24 max-w-40 rounded-md border bg-white">
+      <div
+        className="flex h-8 items-center gap-2 border-b p-2"
+        onDoubleClick={() => openTable(crossBaseId ?? baseId, tableId)}
+      >
+        {icon ? (
+          <Emoji className="size-4 shrink-0" emoji={icon} size={'1rem'} />
+        ) : (
+          <Table2 className="size-4 shrink-0" />
+        )}
+        <span className="text-md  truncate font-bold" title={title}>
+          {title}
+        </span>
+      </div>
+      <div className="flex w-full cursor-default flex-col gap-2">{fieldComponents}</div>
+    </div>
+  );
+});
+
+BaseErdTableNode.displayName = 'BaseErdTableNode';

--- a/apps/nextjs-app/src/features/app/blocks/erd/BaseErdTableNode.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/BaseErdTableNode.tsx
@@ -34,8 +34,8 @@ export const BaseErdTableNode = memo(({ data }: NodeProps<IBaseErdTableNodeProps
     });
 
     return (
-      <div key={field.id} className="relative flex h-6 w-full items-center">
-        <div className="flex w-full items-center gap-2 p-2">
+      <div key={field.id} className="relative flex h-6 w-full items-center p-2">
+        <div className="flex w-full items-center gap-2">
           <Icon className="size-4 shrink-0" />
           <span className=" truncate" title={field.name}>
             {field.name}
@@ -60,9 +60,9 @@ export const BaseErdTableNode = memo(({ data }: NodeProps<IBaseErdTableNodeProps
   });
 
   return (
-    <div key={tableId} className="min-w-24 max-w-40 rounded-md border bg-white">
+    <div key={tableId} className="min-w-28 max-w-36 rounded-md border bg-white ">
       <div
-        className="flex h-8 items-center gap-2 border-b p-2"
+        className=" flex h-10 items-center gap-2 border-b px-2 py-4"
         onDoubleClick={() => openTable(crossBaseId ?? baseId, tableId)}
       >
         {icon ? (
@@ -74,7 +74,9 @@ export const BaseErdTableNode = memo(({ data }: NodeProps<IBaseErdTableNodeProps
           {title}
         </span>
       </div>
-      <div className="flex w-full cursor-default flex-col gap-2">{fieldComponents}</div>
+      <div className="flex w-full cursor-default flex-col gap-2 py-2 text-sm">
+        {fieldComponents}
+      </div>
     </div>
   );
 });

--- a/apps/nextjs-app/src/features/app/blocks/erd/CustomMakers.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/CustomMakers.tsx
@@ -9,14 +9,16 @@ const buildMarkerId = (baseId: string) => {
 
 export const getMarker = (baseId: string, relationship: Relationship) => {
   const { one, many } = buildMarkerId(baseId);
-  const start =
-    relationship === Relationship.OneOne || relationship === Relationship.OneMany ? one : many;
-  const end =
-    relationship === Relationship.OneOne || relationship === Relationship.ManyOne ? one : many;
-  return {
-    start,
-    end,
-  };
+  switch (relationship) {
+    case Relationship.OneOne:
+      return { start: one, end: one };
+    case Relationship.ManyMany:
+      return { start: many, end: many };
+    case Relationship.ManyOne:
+      return { start: many, end: one };
+    case Relationship.OneMany:
+      return { start: one, end: many };
+  }
 };
 export const CustomMarkers = ({ baseId }: { baseId: string }) => {
   // same color as reactflow default marker

--- a/apps/nextjs-app/src/features/app/blocks/erd/CustomMakers.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/CustomMakers.tsx
@@ -1,0 +1,63 @@
+import { Relationship } from '@teable/core';
+
+const buildMarkerId = (baseId: string) => {
+  return {
+    one: `${baseId}-one`,
+    many: `${baseId}-many`,
+  };
+};
+
+export const getMarker = (baseId: string, relationship: Relationship) => {
+  const { one, many } = buildMarkerId(baseId);
+  const start =
+    relationship === Relationship.OneOne || relationship === Relationship.OneMany ? one : many;
+  const end =
+    relationship === Relationship.OneOne || relationship === Relationship.ManyOne ? one : many;
+  return {
+    start,
+    end,
+  };
+};
+export const CustomMarkers = ({ baseId }: { baseId: string }) => {
+  // same color as reactflow default marker
+  const color = 'rgb(177, 177, 183)';
+  return (
+    <svg style={{ position: 'absolute', top: 0, left: 0 }}>
+      <defs>
+        <marker
+          id={buildMarkerId(baseId).one}
+          markerWidth="16"
+          markerHeight="16"
+          viewBox="-10 -10 20 20"
+          markerUnits="strokeWidth"
+          orient="auto-start-reverse"
+          refX="-5"
+          refY="0"
+        >
+          <circle cx="0" cy="0" r="5" fill="none" stroke={color} strokeWidth="1"></circle>
+        </marker>
+        <marker
+          id={buildMarkerId(baseId).many}
+          markerWidth="16"
+          markerHeight="16"
+          viewBox="-10 -10 20 20"
+          markerUnits="strokeWidth"
+          orient="auto-start-reverse"
+          refX="0"
+          refY="4"
+        >
+          <rect
+            x="0"
+            y="0"
+            width="8"
+            height="8"
+            fill="none"
+            stroke={color}
+            strokeWidth="1"
+            transform="rotate(45,4,4)"
+          ></rect>
+        </marker>
+      </defs>
+    </svg>
+  );
+};

--- a/apps/nextjs-app/src/features/app/blocks/erd/DynamicBaseErd.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/DynamicBaseErd.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from '@teable/ui-lib/shadcn';
+import dynamic from 'next/dynamic';
+
+export const DynamicBaseErd = dynamic(() => import('./BaseErd').then((mod) => mod.BaseErd), {
+  loading: () => (
+    <div className="space-y-2 p-4">
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-6 w-full" />
+    </div>
+  ),
+  ssr: false,
+});

--- a/apps/nextjs-app/src/features/app/blocks/erd/SelfConnectingEdge.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/erd/SelfConnectingEdge.tsx
@@ -1,0 +1,18 @@
+import { BezierEdge, BaseEdge, type EdgeProps } from 'reactflow';
+
+export const SelfConnectingEdge = (props: EdgeProps) => {
+  if (props.source !== props.target) {
+    return <BezierEdge {...props} />;
+  }
+
+  const { sourceX, sourceY, targetX, targetY } = props;
+  const x = Math.max(sourceX, targetX);
+  const part = (targetY - sourceY) / 3;
+  const point1 = { x: x + 50, y: sourceY + part };
+  const point2 = { x: x + 50, y: sourceY + part * 2 };
+  const labelX = (point1.x + point2.x) / 2;
+  const labelY = (point1.y + point2.y) / 2;
+
+  const edgePath = `M ${x} ${sourceY} C ${point1.x} ${point1.y} ${point2.x} ${point2.y} ${x} ${targetY}`;
+  return <BaseEdge {...props} path={edgePath} labelX={labelX} labelY={labelY} />;
+};

--- a/apps/nextjs-app/src/pages/_app.tsx
+++ b/apps/nextjs-app/src/pages/_app.tsx
@@ -20,6 +20,7 @@ import { getColorsCssVariablesText } from '@/themes/utils';
 import nextI18nextConfig from '../../next-i18next.config.js';
 import { AppProviders } from '../AppProviders';
 import '@glideapps/glide-data-grid/dist/index.css';
+import 'reactflow/dist/style.css';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/packages/common-i18n/src/locales/de/sdk.json
+++ b/packages/common-i18n/src/locales/de/sdk.json
@@ -273,6 +273,10 @@
       "button": "Button",
       "createdBy": "Erstellt von",
       "lastModifiedBy": "Letzte Änderung von"
+    },
+    "link": {
+      "oneWay": "Einfach",
+      "twoWay": "Doppelt"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/en/sdk.json
+++ b/packages/common-i18n/src/locales/en/sdk.json
@@ -273,6 +273,10 @@
       "button": "Button",
       "createdBy": "Created by",
       "lastModifiedBy": "Last modified by"
+    },
+    "link": {
+      "oneWay": "One Way",
+      "twoWay": "Two Way"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/es/sdk.json
+++ b/packages/common-i18n/src/locales/es/sdk.json
@@ -206,6 +206,10 @@
       "button": "Botón",
       "createdBy": "Creado por",
       "lastModifiedBy": "Última modificación por"
+    },
+    "link": {
+      "oneWay": "Unidireccional",
+      "twoWay": "Bidireccional"
     }
   },
   "formula": {

--- a/packages/common-i18n/src/locales/fr/sdk.json
+++ b/packages/common-i18n/src/locales/fr/sdk.json
@@ -243,6 +243,10 @@
       "button": "Bouton",
       "createdBy": "Créé par",
       "lastModifiedBy": "Dernière modification par"
+    },
+    "link": {
+      "oneWay": "Unidirectionnel",
+      "twoWay": "Bidirectionnel"
     }
   },
   "spaceRole": {

--- a/packages/common-i18n/src/locales/it/sdk.json
+++ b/packages/common-i18n/src/locales/it/sdk.json
@@ -273,6 +273,10 @@
       "button": "Pulsante",
       "createdBy": "Creato da",
       "lastModifiedBy": "Ultima modifica di"
+    },
+    "link": {
+      "oneWay": "Unidirezionale",
+      "twoWay": "Bidirezionale"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/ja/sdk.json
+++ b/packages/common-i18n/src/locales/ja/sdk.json
@@ -246,6 +246,10 @@
       "button": "ボタン",
       "createdBy": "作成者",
       "lastModifiedBy": "最終更新者"
+    },
+    "link": {
+      "oneWay": "一方向",
+      "twoWay": "双方向"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/ru/sdk.json
+++ b/packages/common-i18n/src/locales/ru/sdk.json
@@ -261,6 +261,10 @@
       "button": "Кнопка",
       "createdBy": "Создано",
       "lastModifiedBy": "Изменено"
+    },
+    "link": {
+      "oneWay": "Однонаправленный",
+      "twoWay": "Двунаправленный"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/tr/sdk.json
+++ b/packages/common-i18n/src/locales/tr/sdk.json
@@ -264,6 +264,10 @@
       "button": "Düğme",
       "createdBy": "Oluşturan",
       "lastModifiedBy": "Son değiştiren"
+    },
+    "link": {
+      "oneWay": "Tek yönlü",
+      "twoWay": "Çift yönlü"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/uk/sdk.json
+++ b/packages/common-i18n/src/locales/uk/sdk.json
@@ -273,6 +273,10 @@
       "button": "Кнопка",
       "createdBy": "Створено",
       "lastModifiedBy": "Востаннє змінено"
+    },
+    "link": {
+      "oneWay": "Однонаправленный",
+      "twoWay": "Двунаправленный"
     }
   },
   "permission": {

--- a/packages/common-i18n/src/locales/zh/sdk.json
+++ b/packages/common-i18n/src/locales/zh/sdk.json
@@ -287,6 +287,10 @@
       "button": "按钮",
       "createdBy": "创建人",
       "lastModifiedBy": "最近修改人"
+    },
+    "link": {
+      "oneWay": "单向",
+      "twoWay": "双向"
     }
   },
   "permission": {

--- a/packages/openapi/src/base/erd.ts
+++ b/packages/openapi/src/base/erd.ts
@@ -1,0 +1,82 @@
+import type { RouteConfig } from '@asteasolutions/zod-to-openapi';
+import { FieldType, fieldVoSchema, Relationship } from '@teable/core';
+import { axios } from '../axios';
+import { registerRoute, urlBuilder } from '../utils';
+import { z } from '../zod';
+
+export const BASE_ERD = '/base/{baseId}/erd';
+
+export const baseErdTableNodeSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    icon: z.string().optional(),
+    crossBaseId: z.string().optional(),
+    crossBaseName: z.string().optional(),
+    fields: fieldVoSchema
+      .pick({
+        id: true,
+        name: true,
+        type: true,
+        isLookup: true,
+        isPrimary: true,
+      })
+      .array(),
+  })
+  .passthrough();
+
+export type IBaseErdTableNode = z.infer<typeof baseErdTableNodeSchema>;
+
+export const baseErdEdgeSchema = z.object({
+  source: z.object({
+    tableId: z.string(),
+    tableName: z.string(),
+    fieldId: z.string(),
+    fieldName: z.string(),
+  }),
+  target: z.object({
+    tableId: z.string(),
+    tableName: z.string(),
+    fieldId: z.string(),
+    fieldName: z.string(),
+  }),
+  relationship: z.nativeEnum(Relationship).optional(),
+  isOneWay: z.boolean().optional(),
+  type: z.nativeEnum(FieldType).or(z.literal('lookup')),
+});
+
+export type IBaseErdEdge = z.infer<typeof baseErdEdgeSchema>;
+
+export const baseErdVoSchema = z.object({
+  baseId: z.string(),
+  nodes: z.array(baseErdTableNodeSchema),
+  edges: z.array(baseErdEdgeSchema),
+});
+
+export type IBaseErdVo = z.infer<typeof baseErdVoSchema>;
+
+export const getBaseErdRoute: RouteConfig = registerRoute({
+  method: 'get',
+  path: BASE_ERD,
+  description: 'Get the erd of a base',
+  request: {
+    params: z.object({
+      baseId: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Returns the erd of a base.',
+      content: {
+        'application/json': {
+          schema: baseErdVoSchema,
+        },
+      },
+    },
+  },
+  tags: ['base'],
+});
+
+export const getBaseErd = async (baseId: string) => {
+  return axios.get<IBaseErdVo>(urlBuilder(BASE_ERD, { baseId }));
+};

--- a/packages/openapi/src/base/index.ts
+++ b/packages/openapi/src/base/index.ts
@@ -23,3 +23,4 @@ export * from './collaborator-get-list-user';
 export * from './export';
 export * from './import';
 export * from './move';
+export * from './erd';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,6 +856,9 @@ importers:
       react-virtuoso:
         specifier: 4.7.10
         version: 4.7.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      reactflow:
+        specifier: 11.11.1
+        version: 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: 2.12.3
         version: 2.12.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6269,6 +6272,42 @@ packages:
   '@react-dnd/shallowequal@4.0.2':
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
 
+  '@reactflow/background@11.3.11':
+    resolution: {integrity: sha512-27ahQyHuX2YTc1lABvAPpd5JWBH5P3qTHLGOO+Qfqq4mbicwQ0UGQ2bVDWDwoHOyep2EuMuphrLttaMr0hiviw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/controls@11.2.11':
+    resolution: {integrity: sha512-FyqQv5pWEc2ycEGgIaLPmD5ezW3chsNwqMCjBMETxRj45R4uy6j+gDNi5EgURCan7T12uvoFeQopSZ96JL8XDQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/core@11.11.1':
+    resolution: {integrity: sha512-O9f/q9SZ+29am/XdoZgm/LTdkgQdypcVj9a1yZZgcS6rVDkij1yIiOT3nkGxwnNkJz0rwCn2xtL5SkK038AQ7w==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/minimap@11.7.11':
+    resolution: {integrity: sha512-zXxv+IExvWuaZ+gmRIfmU09A+slG9rMKTVfjqd+ewFV4LFcCyMNMIx3gZybdLZtgUDKIOoU/hAWIY+FbU7GTKw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-resizer@2.2.11':
+    resolution: {integrity: sha512-g/5iLo5vPBoFozU+2WXub+mbpNkQhR+PRX9o0YvH/lYs1pS7JYFSzCOHdHpLHAImoCGrKY1XN5scYly36jWkDw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-toolbar@1.3.11':
+    resolution: {integrity: sha512-PKcTrtC88WZjNQz4ACnPgbNDBprsLJVDxyV1x8drGMNRePPrErkUNxsbhrr49L8ffmIavd4kxW5XVNOx8Kswmw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   '@rollup/plugin-alias@3.1.9':
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
@@ -7430,11 +7469,50 @@ packages:
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
@@ -7442,11 +7520,29 @@ packages:
   '@types/d3-path@3.1.0':
     resolution: {integrity: sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==}
 
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
   '@types/d3-scale@4.0.8':
     resolution: {integrity: sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.6':
     resolution: {integrity: sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
@@ -7456,6 +7552,15 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -7504,6 +7609,9 @@ packages:
 
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
@@ -8274,6 +8382,7 @@ packages:
 
   '@univerjs/sheets-thread-comment-base@0.3.0':
     resolution: {integrity: sha512-JNAMb52Nqf6KY5Usa3tTqilM0lz76xXEFnkDCOqt6Zv7rbLOpgKw1j9MriEov9lCQVFSnmTmabTOdR7iOXzW6w==}
+    deprecated: Package no longer supported.
     peerDependencies:
       '@univerjs/core': 0.3.0
       '@univerjs/engine-formula': 0.3.0
@@ -9424,6 +9533,9 @@ packages:
   class-variance-authority@0.7.0:
     resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -9980,6 +10092,10 @@ packages:
   d3-dispatch@2.0.0:
     resolution: {integrity: sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==}
 
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@1.0.7:
     resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
 
@@ -10009,6 +10125,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -10029,6 +10149,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   dagre-compound@0.0.11:
@@ -15564,6 +15694,12 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  reactflow@11.11.1:
+    resolution: {integrity: sha512-2GEh0bTkYR7rzAV3qdeN6C1o4qumtETZl7yQv1GVrfgr3c77nCUAOKsv5hetRejOGNnJudRwn6axeWFAY+IjNg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -22702,6 +22838,84 @@ snapshots:
 
   '@react-dnd/shallowequal@4.0.2': {}
 
+  '@reactflow/background@11.3.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/controls@11.2.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/core@11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/minimap@11.7.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-resizer@2.2.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-toolbar@1.3.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.2(@types/react@18.2.69)(immer@10.0.4)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rollup/plugin-alias@3.1.9(rollup@2.79.2)':
     dependencies:
       rollup: 2.79.2
@@ -24513,9 +24727,48 @@ snapshots:
 
   '@types/d3-array@3.2.1': {}
 
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
   '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
@@ -24523,19 +24776,73 @@ snapshots:
 
   '@types/d3-path@3.1.0': {}
 
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
   '@types/d3-scale@4.0.8':
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.6':
     dependencies:
       '@types/d3-path': 3.1.0
+
+  '@types/d3-time-format@4.0.3': {}
 
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@2.0.3': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.0
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.8
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.6
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.12':
     dependencies:
@@ -24594,6 +24901,8 @@ snapshots:
     dependencies:
       '@types/jsonfile': 6.1.4
       '@types/node': 20.9.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hammerjs@2.0.46': {}
 
@@ -27114,6 +27423,8 @@ snapshots:
     dependencies:
       clsx: 2.0.0
 
+  classcat@5.0.5: {}
+
   classnames@2.5.1: {}
 
   clean-css@4.2.4:
@@ -27726,6 +28037,11 @@ snapshots:
 
   d3-dispatch@2.0.0: {}
 
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 2.0.0
+      d3-selection: 3.0.0
+
   d3-ease@1.0.7: {}
 
   d3-ease@3.0.1: {}
@@ -27754,6 +28070,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -27771,6 +28089,23 @@ snapshots:
   d3-timer@2.0.0: {}
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 2.0.0
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 2.0.0
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   dagre-compound@0.0.11(dagre@0.8.5):
     dependencies:
@@ -34686,6 +35021,20 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  reactflow@11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@reactflow/background': 11.3.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/controls': 11.2.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.1(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/minimap': 11.7.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/node-resizer': 2.2.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/node-toolbar': 1.3.11(@types/react@18.2.69)(immer@10.0.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   read-cache@1.0.0:
     dependencies:


### PR DESCRIPTION
- Double-click a table title to open a new tab and jump to the specific table page.
- For cross-base relationships, only one level is expanded. For example, if BaseA-Table1 -> BaseB-Table1 -> BaseC-Table1, when viewing the ER diagram for BaseA, BaseB-Table1 is visible, but BaseC-Table1 is not.
- Field references within the same table are located on the right.
- For two-way relationships, if symmetricfieldA -> fieldB and symmetricfieldA <- fieldB, only one line is drawn.
- For one-way relationships, lookupFieldA -> fieldB is drawn.