### PR TITLE
fix: link update option error

### DIFF
--- a/apps/nestjs-backend/src/features/field/field-calculate/field-supplement.service.ts
+++ b/apps/nestjs-backend/src/features/field/field-calculate/field-supplement.service.ts
@@ -294,6 +294,26 @@ export class FieldSupplementService {
         });
     }
 
+    const isSameSymmetricFieldId =
+      (!symmetricFieldId && !oldOptions.symmetricFieldId) ||
+      symmetricFieldId === oldOptions.symmetricFieldId;
+
+    if (
+      newOptionsRo.foreignTableId === oldOptions.foreignTableId &&
+      newOptionsRo.relationship === oldOptions.relationship &&
+      isSameSymmetricFieldId
+    ) {
+      return {
+        ...newOptionsRo,
+        isOneWay: isOneWay || false,
+        symmetricFieldId,
+        lookupFieldId,
+        fkHostTableName: oldOptions.fkHostTableName,
+        selfKeyName: oldOptions.selfKeyName,
+        foreignKeyName: oldOptions.foreignKeyName,
+      };
+    }
+
     return this.generateLinkOptionsVo({
       tableId,
       optionsRo: newOptionsRo,


### PR DESCRIPTION
when the relationship does not change, just change the link option lookupFieldId to generate a new selfKeyName in generateLinkOptionsVo, but linkOptionsChange does not actually generate a new one, causing getForeignKeys to report an error when calculating the record.