### PR TITLE
fix: create field timeout when too many view

### DIFF
--- a/apps/nestjs-backend/src/features/field/open-api/field-open-api.service.ts
+++ b/apps/nestjs-backend/src/features/field/open-api/field-open-api.service.ts
@@ -182,29 +182,32 @@ export class FieldOpenApiService {
     tableId: string,
     fields: (IFieldVo & { columnMeta?: IColumnMeta; references?: string[] })[]
   ) {
-    const newFields = await this.prismaService.$tx(async () => {
-      const newFields: { tableId: string; field: IFieldInstance }[] = [];
-      for (let i = 0; i < fields.length; i++) {
-        const field = fields[i];
-        const { columnMeta, references, ...fieldVo } = field;
+    const newFields = await this.prismaService.$tx(
+      async () => {
+        const newFields: { tableId: string; field: IFieldInstance }[] = [];
+        for (let i = 0; i < fields.length; i++) {
+          const field = fields[i];
+          const { columnMeta, references, ...fieldVo } = field;
 
-        const fieldInstance = createFieldInstanceByVo(fieldVo);
+          const fieldInstance = createFieldInstanceByVo(fieldVo);
 
-        const createResult = await this.fieldCreatingService.alterCreateField(
-          tableId,
-          fieldInstance,
-          columnMeta
-        );
+          const createResult = await this.fieldCreatingService.alterCreateField(
+            tableId,
+            fieldInstance,
+            columnMeta
+          );
 
-        if (references) {
-          await this.restoreReference(references);
+          if (references) {
+            await this.restoreReference(references);
+          }
+
+          newFields.push(...createResult);
         }
 
-        newFields.push(...createResult);
-      }
-
-      return newFields;
-    });
+        return newFields;
+      },
+      { timeout: this.thresholdConfig.bigTransactionTimeout }
+    );
 
     await this.prismaService.$tx(
       async () => {
@@ -239,9 +242,13 @@ export class FieldOpenApiService {
     const columnMeta = fieldRo.order && {
       [fieldRo.order.viewId]: { order: fieldRo.order.orderIndex },
     };
-    const newFields = await this.prismaService.$tx(async () => {
-      return await this.fieldCreatingService.alterCreateField(tableId, fieldInstance, columnMeta);
-    });
+
+    const newFields = await this.prismaService.$tx(
+      async () => {
+        return await this.fieldCreatingService.alterCreateField(tableId, fieldInstance, columnMeta);
+      },
+      { timeout: this.thresholdConfig.bigTransactionTimeout }
+    );
 
     await this.prismaService.$tx(
       async () => {


### PR DESCRIPTION
enhance transaction handling and timeout configuration in field creation process
- too many view (eg: 90 )need to initViewColumnMeta spend a lot of time