### PR TITLE
Prioritize prefix matches when searching in select/multiselect dropdown

### DIFF
--- a/packages/sdk/src/components/editor/select/EditorMain.tsx
+++ b/packages/sdk/src/components/editor/select/EditorMain.tsx
@@ -57,7 +57,28 @@ const SelectEditorMainBase: ForwardRefRenderFunction<
   const filteredOptions = useMemo(() => {
     if (!searchValue) return options;
 
-    return options.filter((v) => v.label.toLowerCase().includes(searchValue.toLowerCase()));
+    const searchLower = searchValue.toLowerCase();
+    const filtered = options.filter((v) => v.label.toLowerCase().includes(searchLower));
+    
+    // Sort to prioritize exact matches and prefix matches
+    return filtered.sort((a, b) => {
+      const aLabelLower = a.label.toLowerCase();
+      const bLabelLower = b.label.toLowerCase();
+      
+      // Check for exact matches first
+      if (aLabelLower === searchLower && bLabelLower !== searchLower) return -1;
+      if (bLabelLower === searchLower && aLabelLower !== searchLower) return 1;
+      
+      // Check for prefix matches
+      const aStartsWith = aLabelLower.startsWith(searchLower);
+      const bStartsWith = bLabelLower.startsWith(searchLower);
+      
+      if (aStartsWith && !bStartsWith) return -1;
+      if (bStartsWith && !aStartsWith) return 1;
+      
+      // If both start with search or neither does, maintain original order
+      return 0;
+    });
   }, [options, searchValue]);
 
   const onSelect = (val: string) => {


### PR DESCRIPTION
Fixes https://github.com/teableio/teable/issues/1903

This was generated by copilot.

If you want I can add a test for this.

I also am just blindly trusting that this effects multiselect in addition to single select, but it might not. If not, let me know and I can fix it up.