### PR TITLE
feat: prisma transaction timeout env

### DIFF
--- a/apps/nextjs-app/.env.example
+++ b/apps/nextjs-app/.env.example
@@ -68,6 +68,13 @@ PRISMA_DATABASE_URL=postgresql://teable:teable@127.0.0.1:5432/teable
 # for external database access
 PUBLIC_DATABASE_PROXY=127.0.0.1:5432
 
+# Prisma Transaction Defaults (optional)
+# Maximum time (ms) a transaction can run before timing out. Default: 5000
+# Increase this for long-running transactions (e.g., bulk updates with many foreign keys)
+# PRISMA_TRANSACTION_TIMEOUT=60000
+# Maximum time (ms) to wait to acquire a transaction from the pool. Default: 2000
+# PRISMA_TRANSACTION_MAX_WAIT=5000
+
 # disable api doc, default is false
 API_DOC_DISENABLED=false
 

--- a/dockers/examples/cluster/.env
+++ b/dockers/examples/cluster/.env
@@ -24,6 +24,13 @@ PUBLIC_ORIGIN=http://127.0.0.1
 PRISMA_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 PUBLIC_DATABASE_PROXY=127.0.0.1:42345
 
+# Prisma Transaction Defaults (optional)
+# Maximum time (ms) a transaction can run before timing out. Default: 5000
+# Increase this if you have long-running transactions (e.g., bulk updates with many links)
+#PRISMA_TRANSACTION_TIMEOUT=60000
+# Maximum time (ms) to wait to acquire a transaction from the pool. Default: 2000
+#PRISMA_TRANSACTION_MAX_WAIT=5000
+
 BACKEND_CACHE_PROVIDER=redis
 BACKEND_CACHE_REDIS_URI=redis://default:${POSTGRES_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}
 

--- a/dockers/examples/standalone/.env
+++ b/dockers/examples/standalone/.env
@@ -18,6 +18,13 @@ PUBLIC_ORIGIN=http://127.0.0.1:3000
 PRISMA_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 PUBLIC_DATABASE_PROXY=127.0.0.1:42345
 
+# Prisma Transaction Defaults (optional)
+# Maximum time (ms) a transaction can run before timing out. Default: 5000
+# Increase this if you have long-running transactions (e.g., bulk updates with many links)
+#PRISMA_TRANSACTION_TIMEOUT=60000
+# Maximum time (ms) to wait to acquire a transaction from the pool. Default: 2000
+#PRISMA_TRANSACTION_MAX_WAIT=5000
+
 # Need to support sending emails to enable the following configurations
 # You need to modify the configuration according to the actual situation, otherwise it will not be able to send emails correctly.
 #BACKEND_MAIL_HOST=smtp.teable.ai

--- a/packages/db-main-prisma/src/prisma.service.ts
+++ b/packages/db-main-prisma/src/prisma.service.ts
@@ -41,6 +41,11 @@ export class PrismaService
 
   private afterTxCb?: () => void;
 
+  // Default transaction options from environment variables
+  // Prisma's built-in defaults: timeout=5000ms, maxWait=2000ms
+  private readonly defaultTxTimeout = Number(process.env.PRISMA_TRANSACTION_TIMEOUT ?? 5000);
+  private readonly defaultTxMaxWait = Number(process.env.PRISMA_TRANSACTION_MAX_WAIT ?? 2000);
+
   constructor(private readonly cls: ClsService<{ tx: ITx }>) {
     const logConfig = {
       log: [
@@ -93,6 +98,13 @@ export class PrismaService
       return await fn(txClient);
     }
 
+    // Apply default timeout and maxWait from environment if not explicitly provided
+    const txOptions = {
+      timeout: options?.timeout ?? this.defaultTxTimeout,
+      maxWait: options?.maxWait ?? this.defaultTxMaxWait,
+      ...(options?.isolationLevel && { isolationLevel: options.isolationLevel }),
+    };
+
     await this.cls.runWith(this.cls.get(), async () => {
       result = await super.$transaction<R>(async (prisma) => {
         prisma = proxyClient(prisma);
@@ -107,7 +119,7 @@ export class PrismaService
           this.cls.set('tx.id', undefined);
           this.cls.set('tx.timeStr', undefined);
         }
-      }, options);
+      }, txOptions);
       this.afterTxCb?.();
     });
 

--- a/packages/db-main-prisma/src/prisma.service.ts
+++ b/packages/db-main-prisma/src/prisma.service.ts
@@ -70,6 +70,9 @@ export class PrismaService
     const initialConfig = process.env.NODE_ENV === 'production' ? {} : { ...logConfig };
 
     super(initialConfig);
+
+    // Log transaction timeout configuration on startup (must be after super())
+    console.log(`[PrismaService] Transaction defaults: timeout=${this.defaultTxTimeout}ms, maxWait=${this.defaultTxMaxWait}ms (from env: PRISMA_TRANSACTION_TIMEOUT=${process.env.PRISMA_TRANSACTION_TIMEOUT}, PRISMA_TRANSACTION_MAX_WAIT=${process.env.PRISMA_TRANSACTION_MAX_WAIT})`);
   }
 
   bindAfterTransaction(fn: () => void) {


### PR DESCRIPTION
This PR resolves the core issue in https://github.com/teableio/teable/issues/1869 using a flexible timeout mechanism.

## Summary

This PR enhances the recently added Prisma transaction timeout configuration with diagnostic logging and adds a Dockerfile for patching official Enterprise Edition images with source code fixes.

## Changes

  1. Add Diagnostic Logging for Transaction Timeout Configuration

Adds startup logging to PrismaService to help self-hosters verify their transaction timeout configuration is being applied correctly.

  Example log output:
  ```
 [PrismaService] Transaction defaults: timeout=60000ms, maxWait=5000ms (from env: PRISMA_TRANSACTION_TIMEOUT=60000, PRISMA_TRANSACTION_MAX_WAIT=5000)
```

  This is particularly useful when debugging timeout issues or confirming environment variables are being read correctly.

##  Motivation

  This PR was created while troubleshooting transaction timeout errors on records with many foreign key relationships. The diagnostic  logging helped confirm the environment variables were being applied, and the patching Dockerfile enabled deploying the fix to  production while waiting for an official release.

  Testing

  - ✅ Verified timeout configuration via startup logs
  - ✅ Confirmed timeout errors resolved with PRISMA_TRANSACTION_TIMEOUT=60000