### PR TITLE
fix(field): invalidate field loader cache after batch update [T1437]

### DIFF
--- a/apps/nestjs-backend/src/features/field/field.service.ts
+++ b/apps/nestjs-backend/src/features/field/field.service.ts
@@ -1129,6 +1129,9 @@ export class FieldService implements IReadonlyAdapterService {
     }));
 
     await this.batchService.saveRawOps(tableId, RawOpType.Edit, IdPrefix.Field, dataList);
+
+    // Invalidate field loader cache to ensure subsequent queries get fresh data
+    this.invalidateFieldLoader(tableId);
   }
 
   async batchDeleteFields(


### PR DESCRIPTION
When updating conditional lookup field's lookupFieldId, values would
briefly show correctly then become empty. This was caused by DataLoader
cache not being invalidated after batchUpdateFields, causing subsequent
queries to use stale field definitions.

Added cache invalidation at the end of batchUpdateFields to ensure
subsequent getTableDomainById calls get fresh data from database.


---
**Related Issues:** T1437