### PR TITLE
Add markdown display support for long text fields

### DIFF
--- a/apps/nextjs-app/src/features/app/components/field-setting/options/LongTextOptions.tsx
+++ b/apps/nextjs-app/src/features/app/components/field-setting/options/LongTextOptions.tsx
@@ -1,6 +1,7 @@
-import type { ILongTextFieldOptions } from '@teable/core';
+import type { ILongTextFieldOptions, ILongTextShowAs } from '@teable/core';
 import { Textarea } from '@teable/ui-lib/shadcn';
 import { DefaultValue } from '../DefaultValue';
+import { LongTextShowAs } from '../show-as/LongTextShowAs';
 
 export const LongTextOptions = (props: {
   options: Partial<ILongTextFieldOptions> | undefined;
@@ -11,7 +12,15 @@ export const LongTextOptions = (props: {
 
   const onDefaultValueChange = (defaultValue: string | undefined) => {
     onChange?.({
+      ...options,
       defaultValue: defaultValue ?? null,
+    });
+  };
+
+  const onShowAsChange = (showAs?: ILongTextShowAs) => {
+    onChange?.({
+      ...options,
+      showAs,
     });
   };
 
@@ -27,6 +36,7 @@ export const LongTextOptions = (props: {
           />
         </DefaultValue>
       )}
+      <LongTextShowAs showAs={options?.showAs} onChange={onShowAsChange} />
     </div>
   );
 };

--- a/apps/nextjs-app/src/features/app/components/field-setting/show-as/LongTextShowAs.tsx
+++ b/apps/nextjs-app/src/features/app/components/field-setting/show-as/LongTextShowAs.tsx
@@ -1,0 +1,57 @@
+import { LongTextDisplayType } from '@teable/core';
+import type { ILongTextShowAs } from '@teable/core';
+import { Label } from '@teable/ui-lib/shadcn/ui/label';
+import { Tabs, TabsList, TabsTrigger } from '@teable/ui-lib/shadcn/ui/tabs';
+import { useTranslation } from 'next-i18next';
+import { tableConfig } from '@/features/i18n/table.config';
+
+const textFlag = 'plainText';
+
+interface ILongTextShowAsProps {
+  showAs?: ILongTextShowAs;
+  onChange?: (showAs?: ILongTextShowAs) => void;
+}
+
+export const LongTextShowAs: React.FC<ILongTextShowAsProps> = (props) => {
+  const { showAs, onChange } = props;
+  const { type } = (showAs || {}) as ILongTextShowAs;
+  const selectedType = showAs == null ? textFlag : type;
+  const { t } = useTranslation(tableConfig.i18nNamespaces);
+
+  const updateDisplayType = (type: string) => {
+    const newShowAs =
+      type === textFlag
+        ? undefined
+        : {
+            ...showAs,
+            type,
+          };
+    onChange?.(newShowAs as ILongTextShowAs);
+  };
+
+  const LONG_TEXT_DISPLAY_INFOS = [
+    {
+      type: textFlag,
+      text: t('table:field.editor.plainText'),
+    },
+    {
+      type: LongTextDisplayType.Markdown,
+      text: t('table:field.editor.markdown'),
+    },
+  ];
+
+  return (
+    <div className="flex w-full flex-col gap-2" data-testid="long-text-show-as">
+      <Label className="text-sm font-medium">{t('table:field.editor.showAs')}</Label>
+      <Tabs value={selectedType} onValueChange={updateDisplayType} className="w-full">
+        <TabsList className="flex w-full gap-2">
+          {LONG_TEXT_DISPLAY_INFOS.map(({ type, text }) => (
+            <TabsTrigger key={type} value={type} className="flex-1 font-normal">
+              {text}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+};

--- a/packages/common-i18n/src/locales/de/table.json
+++ b/packages/common-i18n/src/locales/de/table.json
@@ -224,6 +224,8 @@
       "url": "Url",
       "email": "E-Mail",
       "phone": "Telfonnummer",
+      "plainText": "Klartext",
+      "markdown": "Markdown",
       "maxNumber": "Maximale Nummer",
       "showNumber": "Zeige Nummer",
       "autoFillDate": "Automatisches Ausfüllen mit aktuellem Datum",

--- a/packages/common-i18n/src/locales/en/table.json
+++ b/packages/common-i18n/src/locales/en/table.json
@@ -259,6 +259,8 @@
       "url": "Url",
       "email": "Email",
       "phone": "Phone",
+      "plainText": "Plain text",
+      "markdown": "Markdown",
       "maxNumber": "Max number",
       "showNumber": "Show number",
       "autoFillDate": "Auto fill with current date",

--- a/packages/common-i18n/src/locales/es/table.json
+++ b/packages/common-i18n/src/locales/es/table.json
@@ -223,6 +223,8 @@
       "url": "Url",
       "email": "Correo electrónico",
       "phone": "Teléfono",
+      "plainText": "Texto sin formato",
+      "markdown": "Markdown",
       "maxNumber": "Número máximo",
       "showNumber": "Numero",
       "autoFillDate": "Llena automática con la fecha actual",

--- a/packages/common-i18n/src/locales/fr/table.json
+++ b/packages/common-i18n/src/locales/fr/table.json
@@ -220,6 +220,8 @@
       "url": "Url",
       "email": "Email",
       "phone": "Téléphone",
+      "plainText": "Texte brut",
+      "markdown": "Markdown",
       "maxNumber": "Nombre maximum",
       "showNumber": "Afficher le nombre",
       "autoFillDate": "Remplir automatiquement avec la date actuelle",

--- a/packages/common-i18n/src/locales/it/table.json
+++ b/packages/common-i18n/src/locales/it/table.json
@@ -224,6 +224,8 @@
       "url": "Url",
       "email": "Email",
       "phone": "Telefono",
+      "plainText": "Testo normale",
+      "markdown": "Markdown",
       "maxNumber": "Numero massimo",
       "showNumber": "Mostra Numero",
       "autoFillDate": "Compila automaticamente con la data corrente",

--- a/packages/common-i18n/src/locales/ja/table.json
+++ b/packages/common-i18n/src/locales/ja/table.json
@@ -220,6 +220,8 @@
       "url": "Url",
       "email": "メール",
       "phone": "電話",
+      "plainText": "プレーンテキスト",
+      "markdown": "Markdown",
       "maxNumber": "最大数",
       "showNumber": "番号を表示",
       "autoFillDate": "現在の日付を自動入力",

--- a/packages/common-i18n/src/locales/ru/table.json
+++ b/packages/common-i18n/src/locales/ru/table.json
@@ -220,6 +220,8 @@
       "url": "URL",
       "email": "Email",
       "phone": "Телефон",
+      "plainText": "Простой текст",
+      "markdown": "Markdown",
       "maxNumber": "Максимальное число",
       "showNumber": "Показать число",
       "autoFillDate": "Автозаполнение текущей датой",

--- a/packages/common-i18n/src/locales/tr/table.json
+++ b/packages/common-i18n/src/locales/tr/table.json
@@ -223,6 +223,8 @@
       "url": "URL",
       "email": "E-posta",
       "phone": "Telefon",
+      "plainText": "Düz metin",
+      "markdown": "Markdown",
       "maxNumber": "Maksimum Sayı",
       "showNumber": "Sayıyı Göster",
       "autoFillDate": "Mevcut tarihle otomatik doldur",

--- a/packages/common-i18n/src/locales/uk/table.json
+++ b/packages/common-i18n/src/locales/uk/table.json
@@ -224,6 +224,8 @@
       "url": "URL",
       "email": "Електронна пошта",
       "phone": "Телефон",
+      "plainText": "Простий текст",
+      "markdown": "Markdown",
       "maxNumber": "Максимальна кількість",
       "showNumber": "Показати номер",
       "autoFillDate": "Автозаповнення поточною датою",

--- a/packages/common-i18n/src/locales/zh/table.json
+++ b/packages/common-i18n/src/locales/zh/table.json
@@ -259,6 +259,8 @@
       "url": "网址",
       "email": "邮件",
       "phone": "电话",
+      "plainText": "纯文本",
+      "markdown": "Markdown",
       "maxNumber": "最大值",
       "showNumber": "显示数值",
       "autoFillDate": "自动填充当前日期",

--- a/packages/core/src/models/field/derivate/long-text-option.schema.ts
+++ b/packages/core/src/models/field/derivate/long-text-option.schema.ts
@@ -1,14 +1,14 @@
 import { z } from '../../../zod';
+import { longTextShowAsSchema } from '../show-as';
 
-export const longTextFieldOptionsSchema = z
-  .object({
-    defaultValue: z
-      .string()
-      .optional()
-      .transform((value) => (typeof value === 'string' ? value.trim() : value))
-      .optional()
-      .nullable(),
-  })
-  .strict();
+export const longTextFieldOptionsSchema = z.object({
+  showAs: longTextShowAsSchema.optional(),
+  defaultValue: z
+    .string()
+    .optional()
+    .transform((value) => (typeof value === 'string' ? value.trim() : value))
+    .optional()
+    .nullable(),
+});
 
 export type ILongTextFieldOptions = z.infer<typeof longTextFieldOptionsSchema>;

--- a/packages/core/src/models/field/show-as/index.ts
+++ b/packages/core/src/models/field/show-as/index.ts
@@ -1,8 +1,10 @@
 import { z } from '../../../zod';
 import { CellValueType } from '../constant';
+import { longTextShowAsSchema } from './long-text';
 import { multiNumberShowAsSchema, numberShowAsSchema, singleNumberShowAsSchema } from './number';
 import { singleLineTextShowAsSchema } from './text';
 
+export * from './long-text';
 export * from './number';
 export * from './text';
 
@@ -26,7 +28,7 @@ export const getShowAsSchema = (
 };
 
 export const unionShowAsSchema = z
-  .union([singleLineTextShowAsSchema.strict(), numberShowAsSchema])
+  .union([singleLineTextShowAsSchema.strict(), longTextShowAsSchema.strict(), numberShowAsSchema])
   .meta({
     description:
       'According to the results of expression parsing to determine different visual effects, where strings, numbers will provide customized "show as"',

--- a/packages/core/src/models/field/show-as/long-text.ts
+++ b/packages/core/src/models/field/show-as/long-text.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export enum LongTextDisplayType {
+  Markdown = 'markdown',
+}
+
+export const longTextShowAsSchema = z
+  .object({
+    type: z.nativeEnum(LongTextDisplayType).meta({
+      description:
+        'can display as markdown in long text field with a button to open a rich text editor',
+    }),
+  })
+  .describe('Only be used in long text field');
+
+export type ILongTextShowAs = z.infer<typeof longTextShowAsSchema>;

--- a/packages/sdk/src/components/cell-value-editor/CellEditorMain.tsx
+++ b/packages/sdk/src/components/cell-value-editor/CellEditorMain.tsx
@@ -6,6 +6,7 @@ import type {
   ILinkCellValue,
   ILinkFieldOptions,
   ILongTextCellValue,
+  ILongTextFieldOptions,
   IMultipleSelectCellValue,
   INumberCellValue,
   IRatingFieldOptions,
@@ -93,6 +94,7 @@ export const CellEditorMain = (props: Omit<ICellValueEditor, 'wrapClassName' | '
           ref={editorRef}
           className={className}
           value={cellValue as ILongTextCellValue}
+          options={options as ILongTextFieldOptions}
           onChange={onChange}
           readonly={readonly}
         />

--- a/packages/sdk/src/components/editor/long-text/Editor.tsx
+++ b/packages/sdk/src/components/editor/long-text/Editor.tsx
@@ -1,18 +1,28 @@
-import { cn } from '@teable/ui-lib';
+import { LongTextDisplayType } from '@teable/core';
+import type { ILongTextFieldOptions } from '@teable/core';
+import { cn, Button } from '@teable/ui-lib';
+import { Maximize2 } from 'lucide-react';
 import type { ForwardRefRenderFunction } from 'react';
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState, useCallback } from 'react';
 import AutoSizeTextarea from 'react-textarea-autosize';
+import { MarkdownPreview } from '../../markdown-editor/MarkDownPreview';
 import type { ICellEditor, IEditorRef } from '../type';
+import { MarkdownExpandModal } from './MarkdownExpandModal';
 
-type ITextEditor = ICellEditor<string | null>;
+interface ILongTextEditor extends ICellEditor<string | null> {
+  options?: ILongTextFieldOptions;
+}
 
-const LongTextEditorBase: ForwardRefRenderFunction<IEditorRef<string>, ITextEditor> = (
+const LongTextEditorBase: ForwardRefRenderFunction<IEditorRef<string>, ILongTextEditor> = (
   props,
   ref
 ) => {
-  const { value, onChange, className, readonly, saveOnBlur = true } = props;
+  const { value, options, onChange, className, readonly, saveOnBlur = true } = props;
   const [text, setText] = useState<string>(value || '');
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const isMarkdown = options?.showAs?.type === LongTextDisplayType.Markdown;
 
   useImperativeHandle(ref, () => ({
     focus: () => inputRef.current?.focus(),
@@ -24,9 +34,70 @@ const LongTextEditorBase: ForwardRefRenderFunction<IEditorRef<string>, ITextEdit
     setText(e.target.value);
   };
 
-  const saveValue = () => {
+  const saveValue = useCallback(() => {
     onChange?.(text || null);
-  };
+  }, [onChange, text]);
+
+  const handleModalChange = useCallback(
+    (newValue: string) => {
+      setText(newValue);
+      onChange?.(newValue || null);
+    },
+    [onChange]
+  );
+
+  const handleExpandClick = useCallback(() => {
+    setIsModalOpen(true);
+  }, []);
+
+  if (isMarkdown) {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <div className="relative">
+          {text ? (
+            <div
+              className={cn(
+                'min-h-[80px] max-h-[200px] overflow-auto rounded-md border border-input bg-background p-2 text-sm',
+                className
+              )}
+            >
+              <MarkdownPreview>{text}</MarkdownPreview>
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'min-h-[80px] rounded-md border border-input bg-background p-2 text-sm text-muted-foreground',
+                className
+              )}
+            >
+              Click the expand button to edit markdown content...
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleExpandClick}
+            className="gap-1"
+            disabled={readonly}
+          >
+            <Maximize2 className="size-4" />
+            <span>Edit Markdown</span>
+          </Button>
+        </div>
+        <MarkdownExpandModal
+          open={isModalOpen}
+          onOpenChange={setIsModalOpen}
+          value={text}
+          onChange={handleModalChange}
+          readonly={readonly}
+          title="Edit Markdown Content"
+        />
+      </div>
+    );
+  }
 
   return (
     <AutoSizeTextarea

--- a/packages/sdk/src/components/editor/long-text/MarkdownExpandModal.tsx
+++ b/packages/sdk/src/components/editor/long-text/MarkdownExpandModal.tsx
@@ -1,0 +1,133 @@
+import {
+  cn,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Button,
+} from '@teable/ui-lib';
+import { X, Maximize2, Minimize2 } from 'lucide-react';
+import { useState, useCallback, useEffect } from 'react';
+import { MarkdownWYSIWYGEditor } from './MarkdownWYSIWYGEditor';
+
+interface IMarkdownExpandModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string;
+  onChange: (value: string) => void;
+  readonly?: boolean;
+  title?: string;
+}
+
+export const MarkdownExpandModal = (props: IMarkdownExpandModalProps) => {
+  const { open, onOpenChange, value, onChange, readonly = false, title = 'Edit Content' } = props;
+  const [localValue, setLocalValue] = useState(value);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setLocalValue(value);
+    }
+  }, [open, value]);
+
+  const handleSave = useCallback(() => {
+    onChange(localValue);
+    onOpenChange(false);
+  }, [localValue, onChange, onOpenChange]);
+
+  const handleCancel = useCallback(() => {
+    setLocalValue(value);
+    onOpenChange(false);
+  }, [value, onOpenChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      }
+      if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [handleCancel, handleSave]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          'flex flex-col gap-0 p-0',
+          isFullscreen
+            ? 'h-screen max-h-screen w-screen max-w-none rounded-none'
+            : 'h-[85vh] max-h-[85vh] w-[90vw] max-w-4xl'
+        )}
+        onKeyDown={handleKeyDown}
+        closeable={false}
+      >
+        <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3">
+          <DialogTitle className="text-base font-medium">{title}</DialogTitle>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={() => setIsFullscreen(!isFullscreen)}
+              title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+            >
+              {isFullscreen ? (
+                <Minimize2 className="size-4" />
+              ) : (
+                <Maximize2 className="size-4" />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={handleCancel}
+              title="Close"
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-hidden p-4">
+          <MarkdownWYSIWYGEditor
+            value={localValue}
+            onChange={setLocalValue}
+            readonly={readonly}
+            className="h-full"
+            minHeight="100%"
+            maxHeight="100%"
+          />
+        </div>
+
+        {!readonly && (
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <div className="text-xs text-muted-foreground">
+              <kbd className="rounded bg-muted px-1.5 py-0.5 text-xs">Ctrl</kbd>
+              {' + '}
+              <kbd className="rounded bg-muted px-1.5 py-0.5 text-xs">S</kbd>
+              {' to save, '}
+              <kbd className="rounded bg-muted px-1.5 py-0.5 text-xs">Esc</kbd>
+              {' to cancel'}
+            </div>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button type="button" size="sm" onClick={handleSave}>
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/sdk/src/components/editor/long-text/MarkdownWYSIWYGEditor.tsx
+++ b/packages/sdk/src/components/editor/long-text/MarkdownWYSIWYGEditor.tsx
@@ -1,0 +1,414 @@
+import { generateAttachmentId } from '@teable/core';
+import type { INotifyVo } from '@teable/openapi';
+import { UploadType } from '@teable/openapi';
+import { cn, Button, Separator } from '@teable/ui-lib';
+import {
+  Bold,
+  Italic,
+  Strikethrough,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Quote,
+  Link,
+  Image,
+  Eye,
+  EyeOff,
+  Minus,
+  CheckSquare,
+  Table,
+} from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { AttachmentManager } from '../attachment/AttachmentManager';
+import { MarkdownPreview } from '../../markdown-editor/MarkDownPreview';
+
+interface IMarkdownWYSIWYGEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  readonly?: boolean;
+  className?: string;
+  minHeight?: string;
+  maxHeight?: string;
+  placeholder?: string;
+}
+
+interface IToolbarButton {
+  icon: React.ReactNode;
+  title: string;
+  action: () => void;
+  isActive?: boolean;
+}
+
+export const MarkdownWYSIWYGEditor = (props: IMarkdownWYSIWYGEditorProps) => {
+  const {
+    value,
+    onChange,
+    readonly = false,
+    className,
+    minHeight = '300px',
+    maxHeight = '100%',
+    placeholder = 'Write your content here...',
+  } = props;
+
+  const [showPreview, setShowPreview] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const getSelectionInfo = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return { start: 0, end: 0, selectedText: '' };
+    return {
+      start: textarea.selectionStart,
+      end: textarea.selectionEnd,
+      selectedText: value.substring(textarea.selectionStart, textarea.selectionEnd),
+    };
+  }, [value]);
+
+  const insertText = useCallback(
+    (before: string, after: string = '', placeholder: string = '') => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const { start, end, selectedText } = getSelectionInfo();
+      const textToInsert = selectedText || placeholder;
+      const newText =
+        value.substring(0, start) + before + textToInsert + after + value.substring(end);
+      onChange(newText);
+
+      setTimeout(() => {
+        textarea.focus();
+        const newCursorPos = start + before.length + textToInsert.length;
+        textarea.setSelectionRange(
+          start + before.length,
+          selectedText ? newCursorPos : newCursorPos
+        );
+      }, 0);
+    },
+    [value, onChange, getSelectionInfo]
+  );
+
+  const insertAtLineStart = useCallback(
+    (prefix: string) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const { start, end } = getSelectionInfo();
+      const lines = value.split('\n');
+      let charCount = 0;
+      let startLine = 0;
+      let endLine = 0;
+
+      for (let i = 0; i < lines.length; i++) {
+        if (charCount + lines[i].length >= start && startLine === 0) {
+          startLine = i;
+        }
+        if (charCount + lines[i].length >= end) {
+          endLine = i;
+          break;
+        }
+        charCount += lines[i].length + 1;
+      }
+
+      for (let i = startLine; i <= endLine; i++) {
+        lines[i] = prefix + lines[i];
+      }
+
+      onChange(lines.join('\n'));
+      setTimeout(() => textarea.focus(), 0);
+    },
+    [value, onChange, getSelectionInfo]
+  );
+
+  const uploadImage = useCallback(
+    async (file: File) => {
+      setIsUploading(true);
+      try {
+        const attachmentManager = new AttachmentManager(1);
+        const attachmentResult = await new Promise<INotifyVo>((resolve, reject) => {
+          attachmentManager.upload(
+            [
+              {
+                id: generateAttachmentId(),
+                instance: file,
+              },
+            ],
+            UploadType.Table,
+            {
+              successCallback: (_, result) => {
+                resolve(result);
+              },
+              errorCallback: (_, error) => {
+                reject(error);
+              },
+            }
+          );
+        });
+
+        const imageUrl = attachmentResult.presignedUrl;
+        const imageName = file.name;
+        insertText(`![${imageName}](`, ')', imageUrl);
+      } catch (error) {
+        console.error('Failed to upload image:', error);
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [insertText]
+  );
+
+  const handleImageUpload = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file && file.type.startsWith('image/')) {
+        uploadImage(file);
+      }
+      e.target.value = '';
+    },
+    [uploadImage]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          e.preventDefault();
+          const file = item.getAsFile();
+          if (file) {
+            uploadImage(file);
+          }
+          return;
+        }
+      }
+    },
+    [uploadImage]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      const files = e.dataTransfer?.files;
+      if (!files?.length) return;
+
+      for (const file of files) {
+        if (file.type.startsWith('image/')) {
+          e.preventDefault();
+          uploadImage(file);
+          return;
+        }
+      }
+    },
+    [uploadImage]
+  );
+
+  const toolbarButtons: IToolbarButton[] = [
+    {
+      icon: <Bold className="size-4" />,
+      title: 'Bold',
+      action: () => insertText('**', '**', 'bold text'),
+    },
+    {
+      icon: <Italic className="size-4" />,
+      title: 'Italic',
+      action: () => insertText('*', '*', 'italic text'),
+    },
+    {
+      icon: <Strikethrough className="size-4" />,
+      title: 'Strikethrough',
+      action: () => insertText('~~', '~~', 'strikethrough'),
+    },
+    {
+      icon: <Code className="size-4" />,
+      title: 'Inline Code',
+      action: () => insertText('`', '`', 'code'),
+    },
+  ];
+
+  const headingButtons: IToolbarButton[] = [
+    {
+      icon: <Heading1 className="size-4" />,
+      title: 'Heading 1',
+      action: () => insertAtLineStart('# '),
+    },
+    {
+      icon: <Heading2 className="size-4" />,
+      title: 'Heading 2',
+      action: () => insertAtLineStart('## '),
+    },
+    {
+      icon: <Heading3 className="size-4" />,
+      title: 'Heading 3',
+      action: () => insertAtLineStart('### '),
+    },
+  ];
+
+  const listButtons: IToolbarButton[] = [
+    {
+      icon: <List className="size-4" />,
+      title: 'Bullet List',
+      action: () => insertAtLineStart('- '),
+    },
+    {
+      icon: <ListOrdered className="size-4" />,
+      title: 'Numbered List',
+      action: () => insertAtLineStart('1. '),
+    },
+    {
+      icon: <CheckSquare className="size-4" />,
+      title: 'Task List',
+      action: () => insertAtLineStart('- [ ] '),
+    },
+  ];
+
+  const blockButtons: IToolbarButton[] = [
+    {
+      icon: <Quote className="size-4" />,
+      title: 'Quote',
+      action: () => insertAtLineStart('> '),
+    },
+    {
+      icon: <Minus className="size-4" />,
+      title: 'Horizontal Rule',
+      action: () => insertText('\n---\n'),
+    },
+    {
+      icon: <Code className="size-4" />,
+      title: 'Code Block',
+      action: () => insertText('\n```\n', '\n```\n', 'code block'),
+    },
+  ];
+
+  const insertButtons: IToolbarButton[] = [
+    {
+      icon: <Link className="size-4" />,
+      title: 'Link',
+      action: () => insertText('[', '](url)', 'link text'),
+    },
+    {
+      icon: <Image className="size-4" />,
+      title: 'Image',
+      action: handleImageUpload,
+    },
+    {
+      icon: <Table className="size-4" />,
+      title: 'Table',
+      action: () =>
+        insertText('\n| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n'),
+    },
+  ];
+
+  const renderToolbarGroup = (buttons: IToolbarButton[]) => (
+    <>
+      {buttons.map((button, index) => (
+        <Button
+          key={index}
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={button.action}
+          title={button.title}
+          disabled={readonly || isUploading}
+        >
+          {button.icon}
+        </Button>
+      ))}
+    </>
+  );
+
+  return (
+    <div className={cn('flex flex-col rounded-md border', className)}>
+      {!readonly && (
+        <div className="flex flex-wrap items-center gap-0.5 border-b bg-muted/30 px-2 py-1">
+          {renderToolbarGroup(toolbarButtons)}
+          <Separator orientation="vertical" className="mx-1 h-6" />
+          {renderToolbarGroup(headingButtons)}
+          <Separator orientation="vertical" className="mx-1 h-6" />
+          {renderToolbarGroup(listButtons)}
+          <Separator orientation="vertical" className="mx-1 h-6" />
+          {renderToolbarGroup(blockButtons)}
+          <Separator orientation="vertical" className="mx-1 h-6" />
+          {renderToolbarGroup(insertButtons)}
+          <div className="ml-auto">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2"
+              onClick={() => setShowPreview(!showPreview)}
+              title={showPreview ? 'Hide Preview' : 'Show Preview'}
+            >
+              {showPreview ? (
+                <>
+                  <EyeOff className="mr-1 size-4" />
+                  <span className="text-xs">Edit</span>
+                </>
+              ) : (
+                <>
+                  <Eye className="mr-1 size-4" />
+                  <span className="text-xs">Preview</span>
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      <div className="flex flex-1" style={{ minHeight, maxHeight }}>
+        {!showPreview && (
+          <div className={cn('flex-1', showPreview && 'hidden')}>
+            <textarea
+              ref={textareaRef}
+              className={cn(
+                'size-full resize-none bg-background p-4 text-sm font-mono',
+                'focus:outline-none',
+                'placeholder:text-muted-foreground'
+              )}
+              style={{ minHeight, maxHeight }}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              onPaste={handlePaste}
+              onDrop={handleDrop}
+              onDragOver={(e) => e.preventDefault()}
+              placeholder={placeholder}
+              readOnly={readonly}
+              disabled={isUploading}
+            />
+          </div>
+        )}
+
+        {showPreview && (
+          <div
+            className="flex-1 overflow-auto bg-background p-4"
+            style={{ minHeight, maxHeight }}
+          >
+            <MarkdownPreview>{value}</MarkdownPreview>
+          </div>
+        )}
+      </div>
+
+      {isUploading && (
+        <div className="border-t bg-muted/30 px-4 py-2 text-sm text-muted-foreground">
+          Uploading image...
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/sdk/src/components/editor/long-text/index.ts
+++ b/packages/sdk/src/components/editor/long-text/index.ts
@@ -1,1 +1,3 @@
 export * from './Editor';
+export * from './MarkdownExpandModal';
+export * from './MarkdownWYSIWYGEditor';


### PR DESCRIPTION
## Summary
This PR adds markdown display and editing capabilities to long text fields. Users can now configure long text fields to display content as markdown with a dedicated WYSIWYG editor for rich text editing.

## Key Changes

### Core Schema & Types
- Added `LongTextDisplayType` enum with `Markdown` option to `@teable/core`
- Created `longTextShowAsSchema` to support markdown display configuration
- Extended `ILongTextFieldOptions` to include optional `showAs` property
- Updated union schema to include long text show-as options

### UI Components
- **LongTextShowAs**: New field setting component allowing users to toggle between plain text and markdown display modes
- **MarkdownWYSIWYGEditor**: Full-featured markdown editor with:
  - Text formatting toolbar (bold, italic, strikethrough, code)
  - Heading levels (H1-H3)
  - List types (bullet, numbered, task lists)
  - Block elements (quotes, code blocks, horizontal rules)
  - Link and image insertion with image upload support
  - Live preview toggle
  - Keyboard shortcuts (Ctrl+S to save, Esc to cancel)
  - Drag-and-drop and paste image support
- **MarkdownExpandModal**: Modal dialog for expanded markdown editing with fullscreen support
- **LongTextEditor**: Updated to detect markdown mode and render appropriate UI (preview + expand button vs. plain textarea)

### Field Configuration
- Updated `LongTextOptions` component to include the new `LongTextShowAs` selector
- Properly spreads existing options when updating to preserve other field settings

### Internationalization
- Added translations for "Plain text" and "Markdown" labels across all supported languages (EN, DE, ES, FR, IT, JA, RU, TR, UK, ZH)

### Cell Editor Integration
- Updated `CellEditorMain` to pass field options to the long text editor
- Editor now respects the `showAs` configuration to render appropriate UI

## Implementation Details
- Markdown rendering uses existing `MarkdownPreview` component
- Image uploads are handled through `AttachmentManager` with proper attachment ID generation
- Editor maintains local state for unsaved changes with cancel/save functionality
- Fullscreen mode available for better editing experience on large content
- Readonly mode properly disables all editing controls

https://claude.ai/code/session_01UeuVodegDcLtwLKhTvfvHH