### PR TITLE
fix: wrap updateRecords with bigTransactionTimeout like createRecords

### DIFF
--- a/apps/nestjs-backend/src/features/record/open-api/record-open-api.service.ts
+++ b/apps/nestjs-backend/src/features/record/open-api/record-open-api.service.ts
@@ -132,10 +132,14 @@ export class RecordOpenApiService {
     windowId?: string,
     isAiInternal?: string
   ) {
-    const res = await this.recordModifyService.updateRecords(
-      tableId,
-      updateRecordsRo as IUpdateRecordsInternalRo,
-      windowId
+    const res = await this.prismaService.$tx(
+      async () =>
+        this.recordModifyService.updateRecords(
+          tableId,
+          updateRecordsRo as IUpdateRecordsInternalRo,
+          windowId
+        ),
+      { timeout: this.thresholdConfig.bigTransactionTimeout }
     );
 
     const appId = this.cls.get('appId');


### PR DESCRIPTION
## Bug Description

`RecordOpenApiService.updateRecords` calls `recordModifyService.updateRecords` directly without wrapping it in a `prismaService.$tx()` block with an explicit timeout. This means update operations fall back to the Prisma default transaction timeout (5 seconds, or the `PRISMA_TRANSACTION_TIMEOUT` env var), rather than using the application-configured `bigTransactionTimeout` (10 minutes by default via `BIG_TRANSACTION_TIMEOUT`).

In contrast, both `multipleCreateRecords` (line 58) and `createRecords` (line 117) already wrap their calls with `{ timeout: this.thresholdConfig.bigTransactionTimeout }`.

This inconsistency causes update operations on records with large link fields (e.g., hundreds or thousands of many-to-many links) to time out, even though the same operation volume succeeds for create operations.

## Steps to Reproduce

1. Set `PRISMA_TRANSACTION_TIMEOUT=5000` (default) or leave unset
2. Create a record with a ManyMany link field containing hundreds of links
3. PATCH the record to update the link field (add/remove links)
4. If the junction table operations (DELETE + INSERT for all links) take more than 5 seconds, the operation fails with Prisma error P2028 (transaction timeout)
5. The same number of links in a createRecords call would succeed because it uses bigTransactionTimeout (10 minutes)

## Expected Behavior

Update operations should use the same `bigTransactionTimeout` as create operations, ensuring consistent timeout behavior across all record mutation operations.

## What This Fix Does

Wraps `updateRecords` in `this.prismaService.$tx()` with `{ timeout: this.thresholdConfig.bigTransactionTimeout }`, matching the pattern already used by `multipleCreateRecords` and `createRecords`.

`updateRecord` (singular) delegates to `updateRecords` (plural), so this fix covers both single and batch update operations.

## Client Information

- **OS**: Linux (Docker container on Google Cloud Run)
- **Database**: PostgreSQL 17 (Google Cloud SQL)

## Platform

Docker standalone (Google Cloud Run)

## Additional Context

This was discovered while investigating a JSONB/junction desync issue in a production deployment. A record with 602 many-to-many links could not be updated because the junction table operations exceeded the default 5-second transaction timeout, even though the deployment had set PRISMA_TRANSACTION_TIMEOUT=60000. The bigTransactionTimeout (configured at 10 minutes) would have been more than sufficient.
