### PR TITLE
fix: sort record IDs in lockForeignRecords to prevent deadlocks

### DIFF
--- a/apps/nestjs-backend/src/features/calculation/link.service.ts
+++ b/apps/nestjs-backend/src/features/calculation/link.service.ts
@@ -1413,9 +1413,11 @@ export class LinkService {
       return;
     }
 
+    const sortedIds = [...recordIds].sort();
     const lockQuery = this.knex(tableMeta.dbTableName)
       .select('__id')
-      .whereIn('__id', recordIds)
+      .whereIn('__id', sortedIds)
+      .orderBy('__id')
       .forUpdate()
       .toQuery();
 


### PR DESCRIPTION
## Bug Description

`lockForeignRecords` in `link.service.ts` uses `SELECT ... FOR UPDATE` to acquire row-level locks on foreign records before modifying link data. However, it passes `recordIds` to `whereIn` without sorting, and PostgreSQL does not guarantee deterministic lock acquisition order for `WHERE IN` clauses.

When two concurrent operations lock overlapping sets of foreign records in different orders, a deadlock can occur. For example:

- Request A needs to lock records `[rec3, rec1, rec2]`
- Request B needs to lock records `[rec2, rec3, rec1]`
- PostgreSQL may acquire locks in different orders for each, causing a deadlock

This is inconsistent with `lockRecordsSql` in `postgres.provider.ts` (line 536) which correctly sorts `recordIds` before `forUpdate()`.

## Steps to Reproduce

1. Create two tables with a ManyOne link field
2. Rapidly update link fields on multiple records that reference overlapping sets of foreign records from concurrent API clients
3. Under sufficient concurrency, deadlocks occur because lock acquisition order is non-deterministic

## Expected Behavior

Lock acquisition should follow a deterministic order to prevent deadlocks between concurrent operations.

## What This Fix Does

1. Sorts the `recordIds` array before passing to `whereIn`
2. Adds `orderBy('__id')` to the lock query

This ensures deterministic lock acquisition order, matching the pattern already used by `lockRecordsSql` in `postgres.provider.ts`.

## Client Information

- **OS**: Linux (Docker container on Google Cloud Run)
- **Database**: PostgreSQL 17 (Google Cloud SQL)

## Platform

Docker standalone (Google Cloud Run)

## Additional Context

Discovered during a deep stability audit of the Teable codebase focused on concurrency issues under high API load. The existing `lockRecordsSql` in the Postgres provider already implements correct sorted locking — this fix brings `lockForeignRecords` into alignment with that pattern.
