### PR TITLE
fix: wrap simpleUpdateRecords with transaction, timeout, and retry

### DIFF
--- a/apps/nestjs-backend/src/features/record/open-api/record-open-api.service.ts
+++ b/apps/nestjs-backend/src/features/record/open-api/record-open-api.service.ts
@@ -160,10 +160,15 @@ export class RecordOpenApiService {
     return res;
   }
 
+  @retryOnDeadlock()
   async simpleUpdateRecords(tableId: string, updateRecordsRo: IUpdateRecordsRo) {
-    return await this.recordModifyService.simpleUpdateRecords(
-      tableId,
-      updateRecordsRo as IUpdateRecordsInternalRo
+    return await this.prismaService.$tx(
+      async () =>
+        this.recordModifyService.simpleUpdateRecords(
+          tableId,
+          updateRecordsRo as IUpdateRecordsInternalRo
+        ),
+      { timeout: this.thresholdConfig.bigTransactionTimeout }
     );
   }
 


### PR DESCRIPTION
## Bug Description

`simpleUpdateRecords` in `RecordOpenApiService` calls the full computation pipeline (computed orchestrator, linkService.planDerivateByLink, commitForeignKeyChanges, batchService.updateRecords) without any transaction wrapping, timeout, or deadlock retry.

If any step fails partway through, junction table changes can be committed while JSONB updates are not, computed field evaluations can be partially applied, and `__version` can be corrupted due to a read-then-write race without FOR UPDATE locking.

This is inconsistent with `updateRecords` which wraps in `$tx` with `bigTransactionTimeout` and `@retryOnDeadlock`.

## What This Fix Does

- Adds `@retryOnDeadlock()` decorator for transient deadlock recovery
- Wraps in `$tx` with `bigTransactionTimeout` for atomicity and timeout protection

Matches the pattern already used by `updateRecords` and `multipleCreateRecords`.

## Client Information

- **OS**: Linux (Docker, Google Cloud Run)
- **Database**: PostgreSQL 17

## Platform

Docker standalone (Google Cloud Run)
