### PR TITLE
fix(core): allow null/undefined values for required fields with defaults

### DIFF
--- a/packages/core/src/models/field/field.ts
+++ b/packages/core/src/models/field/field.ts
@@ -98,12 +98,20 @@ export abstract class FieldCore implements IFieldVo {
 
   /**
    * Wrapper to enforce notNull when calling validateCellValue.
+   * If the field has a default value, null/undefined inputs are allowed
+   * since the default will be applied later.
    */
   validateCellValueWithNotNull(value: unknown): ZodSafeParseResult<unknown> | undefined {
     if (this.isComputed) {
       return this.validateCellValue(value);
     }
     if (this.notNull && (value === null || value === undefined)) {
+      // Check if field has a default value - if so, allow null/undefined
+      // since the default will be applied later
+      const options = this.options as { defaultValue?: unknown } | undefined;
+      if (options?.defaultValue !== undefined) {
+        return this.validateCellValue(value);
+      }
       return {
         success: false,
         error: new ZodError([


### PR DESCRIPTION
## Problem

When a field is required (notNull) and has a default value, creating a new record without explicitly providing a value for that field would fail validation with a 'Required' error. This happened because the validation logic didn't account for the fact that a default value would be applied later in the record creation process.

Fixes #2771

## Solution

Modified `validateCellValueWithNotNull` in the FieldCore class to check if the field has a default value before rejecting null/undefined inputs. If a default value is defined, the validation allows null/undefined to pass through, since the default will be applied later.

## Changes

- Updated `validateCellValueWithNotNull` in `packages/core/src/models/field/field.ts`
- Added check for `options.defaultValue` before returning validation error for null/undefined values

## Testing

This fix ensures that:
1. Required fields without defaults still reject null/undefined values
2. Required fields with defaults allow null/undefined values (default will be applied later)
3. Non-required fields continue to work as before