### PR TITLE
fix(view): stop portal pointer events from bubbling to view tab dnd

### DIFF
--- a/apps/nextjs-app/src/features/app/blocks/view/list/ViewList.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/list/ViewList.tsx
@@ -12,6 +12,7 @@ export const ViewList = () => {
   const permission = useTablePermission();
   const editable = permission['view|update'];
   const [editing, setEditing] = useState(false);
+  const [contextMenuOpen, setContextMenuOpen] = useState(false);
 
   return isHydrated && editable ? (
     views.length ? (
@@ -20,7 +21,7 @@ export const ViewList = () => {
           <div
             ref={setNodeRef}
             {...attributes}
-            {...(editing ? {} : listeners)}
+            {...(editing || contextMenuOpen ? {} : listeners)}
             style={style}
             className={cn('relative', {
               'opacity-50': isDragging,
@@ -28,6 +29,7 @@ export const ViewList = () => {
           >
             <ViewListItem
               onEdit={(value) => setEditing(value)}
+              onContextMenuOpenChange={setContextMenuOpen}
               view={view}
               removable={!!permission['view|delete'] && views.length > 1}
               isActive={view.id === activeViewId}

--- a/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/view/list/ViewListItem.tsx
@@ -42,9 +42,16 @@ interface IProps {
   removable: boolean;
   isActive: boolean;
   onEdit: (value: boolean) => void;
+  onContextMenuOpenChange?: (open: boolean) => void;
 }
 
-export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive, onEdit }) => {
+export const ViewListItem: React.FC<IProps> = ({
+  view,
+  removable,
+  isActive,
+  onEdit,
+  onContextMenuOpenChange,
+}) => {
   const [isEditing, setIsEditing] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -210,7 +217,7 @@ export const ViewListItem: React.FC<IProps> = ({ view, removable, isActive, onEd
 
   return (
     <>
-      <ContextMenu>
+      <ContextMenu onOpenChange={onContextMenuOpenChange}>
         <ContextMenuTrigger asChild disabled={isEditing || isReadOnlyPreview}>
           <div
             ref={viewItemRef}

--- a/packages/ui-lib/src/shadcn/ui/context-menu.tsx
+++ b/packages/ui-lib/src/shadcn/ui/context-menu.tsx
@@ -39,16 +39,29 @@ const ContextMenuSubTrigger = React.forwardRef<
 ));
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
 
+/** Portal content still bubbles through the React tree; stop pointer events from reaching outer dnd-kit listeners. */
+const stopMenuPointerPropagation = (e: React.SyntheticEvent) => {
+  e.stopPropagation();
+};
+
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, onMouseDown, ...props }, ref) => (
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
       'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border-high bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className
     )}
+    onPointerDown={(e) => {
+      stopMenuPointerPropagation(e);
+      onPointerDown?.(e);
+    }}
+    onMouseDown={(e) => {
+      stopMenuPointerPropagation(e);
+      onMouseDown?.(e);
+    }}
     {...props}
   />
 ));
@@ -57,7 +70,7 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, onMouseDown, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
     <ContextMenuPrimitive.Content
       ref={ref}
@@ -65,6 +78,14 @@ const ContextMenuContent = React.forwardRef<
         'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border-high bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
+      onPointerDown={(e) => {
+        stopMenuPointerPropagation(e);
+        onPointerDown?.(e);
+      }}
+      onMouseDown={(e) => {
+        stopMenuPointerPropagation(e);
+        onMouseDown?.(e);
+      }}
       {...props}
     />
   </ContextMenuPrimitive.Portal>

--- a/packages/ui-lib/src/shadcn/ui/dialog.tsx
+++ b/packages/ui-lib/src/shadcn/ui/dialog.tsx
@@ -6,6 +6,21 @@ import * as React from 'react';
 
 import { cn } from '../utils';
 
+/** Portal interactions still bubble through the React tree; stop them from reaching outer dnd-kit listeners. */
+const stopDialogPointerPropagation = (e: React.SyntheticEvent) => {
+  e.stopPropagation();
+};
+
+const mergePointerHandlers = <E extends React.SyntheticEvent>(
+  stop: (e: E) => void,
+  userHandler: ((e: E) => void) | undefined
+) => {
+  return (e: E) => {
+    stop(e);
+    userHandler?.(e);
+  };
+};
+
 const Dialog = DialogPrimitive.Root;
 
 const DialogTrigger = DialogPrimitive.Trigger;
@@ -17,13 +32,15 @@ const DialogClose = DialogPrimitive.Close;
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, onMouseDown, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
       'fixed inset-0 z-50 bg-black/50 dark:bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
+    onPointerDown={mergePointerHandlers(stopDialogPointerPropagation, onPointerDown)}
+    onMouseDown={mergePointerHandlers(stopDialogPointerPropagation, onMouseDown)}
     {...props}
   />
 ));
@@ -52,6 +69,8 @@ const DialogContent = React.forwardRef<
       overlayClassName,
       overlayStyle,
       overlay,
+      onPointerDown,
+      onMouseDown,
       ...props
     },
     ref
@@ -64,6 +83,8 @@ const DialogContent = React.forwardRef<
           'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
           className
         )}
+        onPointerDown={mergePointerHandlers(stopDialogPointerPropagation, onPointerDown)}
+        onMouseDown={mergePointerHandlers(stopDialogPointerPropagation, onMouseDown)}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary

Fixes a bug where dragging inside a view tab context menu or share dialog incorrectly triggered dnd-kit reordering on the view tab strip.

Radix `ContextMenu` and `Dialog` render content in a portal, but React synthetic events still bubble through the component tree to ancestors. View tabs attach dnd-kit `listeners` on a wrapper around `ViewListItem`, so pointer events from portaled overlays activated tab drag.

## Changes

- Stop `pointerdown` / `mousedown` propagation on `ContextMenuContent`, `ContextMenuSubContent`, `DialogOverlay`, and `DialogContent`
- Disable view tab drag listeners while the view context menu is open (`ViewList` / `ViewListItem`)

## Test plan

- [x] Right-click a view tab, drag inside the context menu — tabs should not reorder
- [x] Open share dialog from context menu or toolbar, drag on overlay/content — tabs should not reorder
- [x] Drag view tabs directly (without open overlays) — reordering still works
- [x] Rename / lock view / share actions in menus still work