### PR TITLE
fix: guard table rename against IME composition Enter

### DIFF
--- a/apps/nextjs-app/src/features/app/blocks/table/table-header/TableInfo.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/table/table-header/TableInfo.tsx
@@ -119,7 +119,7 @@ export const TableInfo: React.FC<ITableInfoProps> = (props: ITableInfoProps) => 
               setIsEditing(false);
             }}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                 if (e.currentTarget.value && e.currentTarget.value !== table?.name) {
                   table?.updateName(e.currentTarget.value);
                 }


### PR DESCRIPTION
## Problem

Renaming a table commits the new name on `Enter`. The keydown handler in `TableInfo.tsx` only checks `e.key === 'Enter'`, so it also fires while an IME is composing. When you rename a table in Japanese, Chinese, or Korean, pressing `Enter` to confirm an IME candidate calls `table.updateName()` with the half composed text and closes the editor, instead of just accepting the candidate.

## Why this is a leftover, not intended

The rest of the codebase already treats a composing `Enter` as "do nothing yet":

- `packages/sdk/src/components/grid/hooks/useKeyboardSelection.ts` starts its key handler with `if (keyboardEvent.isComposing) return;`, so the grid never acts on a composing key.
- The filter and search inputs gate their action on `!isComposing` (`packages/sdk/src/components/filter/view-filter/component/base/BaseSingleSelect.tsx`, `packages/sdk/src/components/member-selector/SearchInput.tsx`).

This single rename input is missing the same guard.

## Changes

Add `!e.nativeEvent.isComposing` to the `Enter` check, matching the grid's `isComposing` guard.

```tsx
if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
```

Outside of IME input `isComposing` is always `false`, so this is a no op for normal typing: a plain `Enter` still commits the rename, and the existing `onBlur` commit path is untouched.

## How this was tested

I did not run the full app test suite for this one line guard. I checked the logic against the three relevant keydown shapes:

- composing `Enter` (`key: 'Enter'`, `isComposing: true`, seen on Safari/WebKit when confirming a candidate): before this change the rename fires; after, it is skipped and composition continues.
- plain `Enter` (`isComposing: false`): commits the rename, unchanged.
- on Chromium the composition confirming `Enter` is typically reported as `keyCode 229` rather than `key === 'Enter'`, so the handler does not fire there either way and the guard is harmless.
