### PR TITLE
fix: exclude PG18 NOT NULL constraint rows from migration validation signature

### DIFF
--- a/apps/nestjs-backend/src/features/space/space-data-db-migration.service.ts
+++ b/apps/nestjs-backend/src/features/space/space-data-db-migration.service.ts
@@ -6345,6 +6345,10 @@ export class SpaceDataDbMigrationService {
           LEFT JOIN pg_namespace referenced_ns ON referenced_ns.oid = referenced_rel.relnamespace
           WHERE n.nspname = ?
             AND c.relname = ?
+            -- PG18+ materializes NOT NULL as pg_constraint rows (contype 'n'); older
+            -- majors don't, so comparing source/target across versions would always
+            -- mismatch. NOT NULL-ness is already covered by the column signatures.
+            AND con.contype <> 'n'
             ${scopedForeignKeySql}
           ORDER BY con.contype ASC, con.conname ASC
         `,


### PR DESCRIPTION
## Problem

PostgreSQL 18 materializes NOT NULL constraints as real `pg_constraint` rows (`contype = 'n'`, see PG18 release notes "Store NOT NULL constraints in pg_catalog"). Older majors do not.

When a BYODB space migration targets a PG18+ database while the source runs PG ≤17, the constraint-signature comparison sees extra `<table>___<col>_not_null` rows on the target side only. Every relation then fails with `constraint_signature_mismatch` and the migration is rolled back — PG18 targets are effectively unusable.

Example mismatch captured live (source PG16 → target PG18.4 on CNPG):

```
sourceConstraints: [PRIMARY KEY (__auto_number), UNIQUE (__id)]
targetConstraints: [NOT NULL __auto_number, NOT NULL __created_by, ..., PRIMARY KEY (__auto_number), UNIQUE (__id)]
```

## Fix

Filter `contype = 'n'` out of the constraint signature query. NOT NULL-ness is already validated by the column signature comparison (`attnotnull`), so this loses no validation strength on any PG version, and keeps signatures comparable across majors.

## Verification

Ran the full flow against a CloudNativePG PostgreSQL 18.4 target with a real space (57 tables, 3 bases):

- without the filter: copy succeeds, validation fails on **60 relations**, migration rolls back
- with the filter: copy + validation (0 mismatches) + switch + post-switch CRUD (create table / insert / update / read / delete) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)