### PR TITLE
ci: pin actions-hub/kubectl to a full commit SHA

### DIFF
--- a/.github/workflows/manual-preview.yml
+++ b/.github/workflows/manual-preview.yml
@@ -110,21 +110,21 @@ jobs:
           sed -i "s#__DISPLAY_NAME__#${{ env.DISPLAY_NAME }}#g" deploy.yaml
 
       - name: Apply deploy job
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@0456ef3aefab85c135a0e285bc3b5c600372eea2 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: apply -f deploy.yaml
 
       - name: Rollout status
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@0456ef3aefab85c135a0e285bc3b5c600372eea2 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: rollout status deployment/teable-${{ env.INSTANCE_NAME }} --timeout=300s
 
       - name: Wait for application health check
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@0456ef3aefab85c135a0e285bc3b5c600372eea2 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,7 +30,7 @@ jobs:
           sed -i "s#__DISPLAY_NAME__#${{ env.DISPLAY_NAME }}#g" deploy.yaml
 
       - name: Delete deployment
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@0456ef3aefab85c135a0e285bc3b5c600372eea2 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:


### PR DESCRIPTION
### What
Pin `actions-hub/kubectl@master` → `0456ef3…` in `manual-preview.yml` (×3) and `preview-cleanup.yml`
(tag kept in a comment).

### Why
These deploy/cleanup steps set `KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}` — a full Kubernetes kubeconfig
— in the environment of a third-party action pinned to the moving `@master` ref. If that action's
`master` were moved (compromise or an accidental change), the new code would run in the runner with
cluster credentials present — the class of issue behind the 2025 `tj-actions/changed-files` incident,
here with Kubernetes cluster access. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the KUBE_CONFIG exposure, and the pinned SHA myself.</sub>
