### PR TITLE
fix: auto-focus search box when link record selector opens

### DIFF
--- a/packages/sdk/src/components/editor/link/EditorMain.tsx
+++ b/packages/sdk/src/components/editor/link/EditorMain.tsx
@@ -235,7 +235,7 @@ const LinkEditorInnerBase: ForwardRefRenderFunction<ILinkEditorMainRef, ILinkEdi
         </div>
       </div>
       <div className="flex items-center justify-between">
-        <SearchInput container={props.container} />
+        <SearchInput container={props.container} autoFocus />
         <div className="ml-4">
           <Tabs
             value={listType === LinkListType.Selected ? 'selected' : 'all'}

--- a/packages/sdk/src/components/search/SearchInput.tsx
+++ b/packages/sdk/src/components/search/SearchInput.tsx
@@ -34,10 +34,12 @@ export function SearchInput({
   className,
   container,
   globalOnly,
+  autoFocus,
 }: {
   className?: string;
   container?: HTMLElement;
   globalOnly?: boolean;
+  autoFocus?: boolean;
 }) {
   const { maxSearchFieldCount = DEFAULT_MAX_SEARCH_FIELD_COUNT } = useContext(AppContext) ?? {};
   const fields = useFields();
@@ -57,6 +59,13 @@ export function SearchInput({
   useEffect(() => {
     setHideNotMatchRow(true);
   }, [setHideNotMatchRow]);
+
+  useEffect(() => {
+    if (autoFocus) {
+      ref.current?.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [, cancel] = useDebounce(
     () => {


### PR DESCRIPTION
## Summary
- The linked-record row selector's search input didn't receive focus when the popup opened, so users had to click into it before they could start typing (issue also notes the popup itself requires a double-click to open, which is existing, consistent grid behavior shared by every field type's cell editor).
- Auto-focuses the search input on mount in `SearchInput` (new optional `autoFocus` prop, opt-in so the other consumer of this shared component, the settings query builder's persistent search bar, is unaffected) and wires it up from the link editor's `EditorMain`.

## Why this option (of the two proposed in the issue)
The issue offered two options: make the cell searchable on a single click, or keep the existing double-click-to-open flow and just auto-focus the search box. Went with the latter: double-click-to-edit is the grid's shared activation gesture across every field type (`packages/sdk/src/components/grid/InteractionLayer.tsx`'s `onDblClick`), so changing it for link fields only would special-case one field type against the whole interaction model (single click is also used for cell selection/range-select) for a much larger, riskier change. Auto-focusing the search input is a small, localized fix that removes the actual friction described (an extra click before typing).

## Test plan
- [x] Manually reviewed the diff line-by-line (imports, hook ordering, prop plumbing) for correctness.
- [ ] Could not run `pnpm install`/build/lint/typecheck in my environment (tooling install was blocked by sandbox restrictions with no interactive approval available). Noting this rather than claiming it was verified. Happy to address any build/lint feedback from CI.

Fixes #2928
