### PR TITLE
Fix POWER formula returning the base for a zero exponent

### DIFF
--- a/packages/core/src/formula/functions/numeric.ts
+++ b/packages/core/src/formula/functions/numeric.ts
@@ -576,7 +576,7 @@ export class Power extends NumericFunc {
   eval(params: TypedValue<number | null>[]): number | null {
     const value = params[0].value;
     if (value == null) return null;
-    const exponent = params[1]?.value || 1;
+    const exponent = params[1]?.value ?? 1;
     return Math.pow(value, exponent);
   }
 }


### PR DESCRIPTION
## Problem

The `POWER(base, exponent)` formula function (`packages/core/src/formula/functions/numeric.ts`) reads its exponent with a truthy fallback:

```ts
eval(params: TypedValue<number | null>[]): number | null {
  const value = params[0].value;
  if (value == null) return null;
  const exponent = params[1]?.value || 1;
  return Math.pow(value, exponent);
}
```

`POWER(x, 0)` must return `1` (the identity x⁰ = 1), but `0 || 1` evaluates to `1`, so the exponent silently becomes `1` and the function returns the **base** `x` instead of `1`.

`validateParams` throws when fewer than 2 params are supplied, so `params[1]` always exists at eval time — the `|| 1` "default" is never needed for a missing argument, and its only reachable effect is corrupting an explicitly-passed `0`.

## Evidence (siblings prove intent)

`Ceiling` and `Floor` in the same file use `params[1]?.value || 0` — harmless because their default (`0`) *equals* the falsy value. `Power` is the one case where the default (`1`) differs from the meaningful falsy input (`0`), so `|| 1` can only ever misfire.

## Reproduction

| formula | expected | before | after |
|---|---|---|---|
| `POWER(2, 0)` | 1 | **2** ❌ | 1 ✅ |
| `POWER(10, 0)` | 1 | **10** ❌ | 1 ✅ |
| `POWER(2, 3)` | 8 | 8 | 8 |

## Fix

```ts
const exponent = params[1]?.value ?? 1;
```

`??` preserves the null-safety intent while honoring an explicit `0`. Existing tests (`numeric.spec.ts`) only cover exponents 2 and -2, so the zero case was unguarded.
