### PR TITLE
feat: add MiniMax provider presets

### DIFF
--- a/apps/nestjs-backend/src/features/ai/util.spec.ts
+++ b/apps/nestjs-backend/src/features/ai/util.spec.ts
@@ -1,0 +1,47 @@
+import { LLMProviderType, MINIMAX_PROVIDER_ENDPOINTS } from '@teable/openapi';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const providerMocks = vi.hoisted(() => ({
+  createMessagesProvider: vi.fn(() => 'messages-provider'),
+  createChatProvider: vi.fn(() => 'chat-provider'),
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: providerMocks.createMessagesProvider,
+}));
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: providerMocks.createChatProvider,
+}));
+
+import { modelProviders } from './util';
+
+describe('MiniMax provider routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the chat provider for chat completion endpoints', () => {
+    const options = {
+      name: 'MiniMax-M3',
+      baseURL: MINIMAX_PROVIDER_ENDPOINTS[0].baseUrl,
+      apiKey: 'test-key',
+    };
+
+    expect(modelProviders[LLMProviderType.MINIMAX](options)).toBe('chat-provider');
+    expect(providerMocks.createChatProvider).toHaveBeenCalledWith(options);
+    expect(providerMocks.createMessagesProvider).not.toHaveBeenCalled();
+  });
+
+  it('uses the messages provider for messages endpoints', () => {
+    const options = {
+      name: 'MiniMax-M3',
+      baseURL: MINIMAX_PROVIDER_ENDPOINTS[2].baseUrl,
+      apiKey: 'test-key',
+    };
+
+    expect(modelProviders[LLMProviderType.MINIMAX](options)).toBe('messages-provider');
+    expect(providerMocks.createMessagesProvider).toHaveBeenCalledWith(options);
+    expect(providerMocks.createChatProvider).not.toHaveBeenCalled();
+  });
+});

--- a/apps/nestjs-backend/src/features/ai/util.ts
+++ b/apps/nestjs-backend/src/features/ai/util.ts
@@ -11,7 +11,7 @@ import { createTogetherAI } from '@ai-sdk/togetherai';
 import { createXai } from '@ai-sdk/xai';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import type { IAIConfig, Task } from '@teable/openapi';
-import { LLMProviderType } from '@teable/openapi';
+import { isMiniMaxMessagesEndpoint, LLMProviderType } from '@teable/openapi';
 import { get } from 'lodash';
 import { createOllama } from 'ollama-ai-provider-v2';
 import { TASK_MODEL_MAP } from './constant';
@@ -88,6 +88,13 @@ const createOpenAICompatibleWrapper = (
   });
 };
 
+const createMiniMax = (options: Parameters<typeof createOpenAICompatible>[0]) => {
+  if (isMiniMaxMessagesEndpoint(options.baseURL)) {
+    return createAnthropic(options);
+  }
+  return createOpenAICompatible(options);
+};
+
 export const modelProviders = {
   [LLMProviderType.OPENAI]: createOpenAI,
   [LLMProviderType.ANTHROPIC]: createAnthropic,
@@ -96,6 +103,7 @@ export const modelProviders = {
   [LLMProviderType.COHERE]: createCohere,
   [LLMProviderType.MISTRAL]: createMistral,
   [LLMProviderType.DEEPSEEK]: createDeepSeek,
+  [LLMProviderType.MINIMAX]: createMiniMax,
   [LLMProviderType.QWEN]: createOpenAICompatible,
   [LLMProviderType.ZHIPU]: createOpenAICompatible,
   [LLMProviderType.LINGYIWANWU]: createOpenAICompatible,

--- a/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.spec.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.spec.tsx
@@ -49,6 +49,27 @@ beforeEach(() => {
 });
 
 describe('LLMProviderForm', () => {
+  it('applies the MiniMax endpoint and model presets', async () => {
+    render(<LLMProviderForm onAdd={vi.fn()} onTest={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('option', { name: /MiniMax/ }));
+
+    expect(screen.getByDisplayValue('https://api.minimax.io/v1')).toBeInTheDocument();
+    expect(screen.getByText('MiniMax-M3')).toBeInTheDocument();
+    expect(screen.getByText('MiniMax-M2.7')).toBeInTheDocument();
+    expect(
+      Array.from(document.querySelectorAll('datalist option')).map((option) =>
+        option.getAttribute('value')
+      )
+    ).toEqual([
+      'https://api.minimax.io/v1',
+      'https://api.minimaxi.com/v1',
+      'https://api.minimax.io/anthropic',
+      'https://api.minimaxi.com/anthropic',
+    ]);
+  });
+
   it('does not allow a new provider to save display-only edits without a connection test', async () => {
     render(<LLMProviderForm onAdd={vi.fn()} onTest={vi.fn()} />);
 

--- a/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.tsx
@@ -1259,6 +1259,9 @@ export const LLMProviderForm = ({
   const canSaveWithoutTest = Boolean(value) && isDirty && !connectivityDirty;
   const type = form.watch('type');
   const currentProvider = LLM_PROVIDERS.find((provider) => provider.value === type);
+  const baseUrlPresetListId = currentProvider?.baseUrlPresets?.length
+    ? `llm-provider-${type}-base-urls`
+    : undefined;
   const providerOptions = LLM_PROVIDERS.filter(
     (provider) => !provider.hideInProviderSelect || provider.value === type
   );
@@ -1314,7 +1317,20 @@ export const LLMProviderForm = ({
               <Select
                 {...field}
                 onValueChange={(value) => {
-                  form.setValue('type', value as unknown as LLMProvider['type']);
+                  const nextType = value as unknown as LLMProvider['type'];
+                  const nextProvider = LLM_PROVIDERS.find(
+                    (provider) => provider.value === nextType
+                  );
+                  form.setValue('type', nextType);
+                  if (nextProvider?.defaults) {
+                    form.setValue('baseUrl', nextProvider.defaults.baseUrl, { shouldDirty: true });
+                    form.setValue('models', nextProvider.defaults.models, { shouldDirty: true });
+                    form.setValue(
+                      'modelConfigs',
+                      structuredClone(nextProvider.defaults.modelConfigs ?? {}),
+                      { shouldDirty: true }
+                    );
+                  }
                 }}
               >
                 <SelectTrigger className="w-[180px]">
@@ -1347,8 +1363,19 @@ export const LLMProviderForm = ({
                   <FormDescription>{t('admin.setting.ai.baseUrlDescription')}</FormDescription>
                 </div>
                 <FormControl>
-                  <Input {...field} placeholder={currentProvider.baseUrlPlaceholder} />
+                  <Input
+                    {...field}
+                    list={baseUrlPresetListId}
+                    placeholder={currentProvider.baseUrlPlaceholder}
+                  />
                 </FormControl>
+                {baseUrlPresetListId && (
+                  <datalist id={baseUrlPresetListId}>
+                    {currentProvider.baseUrlPresets?.map((preset) => (
+                      <option key={preset.baseUrl} value={preset.baseUrl} label={preset.label} />
+                    ))}
+                  </datalist>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/constant.ts
+++ b/apps/nextjs-app/src/features/app/blocks/admin/setting/components/ai-config/constant.ts
@@ -35,8 +35,13 @@ import {
   Prodia,
   Recraft,
 } from '@teable/icons';
-import type { GatewayModelProvider } from '@teable/openapi';
-import { LLMProviderType } from '@teable/openapi';
+import type { GatewayModelProvider, LLMProvider } from '@teable/openapi';
+import {
+  LLMProviderType,
+  MINIMAX_DEFAULT_MODEL_CONFIGS,
+  MINIMAX_MODEL_IDS,
+  MINIMAX_PROVIDER_ENDPOINTS,
+} from '@teable/openapi';
 
 export const LLM_PROVIDER_ICONS = {
   [LLMProviderType.OPENAI]: Openai,
@@ -46,6 +51,7 @@ export const LLM_PROVIDER_ICONS = {
   [LLMProviderType.COHERE]: Cohere,
   [LLMProviderType.MISTRAL]: Mistral,
   [LLMProviderType.DEEPSEEK]: Deepseek,
+  [LLMProviderType.MINIMAX]: Minimax,
   [LLMProviderType.QWEN]: Qwen,
   [LLMProviderType.ZHIPU]: Zhipu,
   [LLMProviderType.LINGYIWANWU]: Lingyiwanwu,
@@ -66,7 +72,16 @@ type LLMProviderOption = {
   apiKeyPlaceholder?: string;
   Icon: React.ComponentType<{ className?: string }>;
   hideInProviderSelect?: boolean;
+  baseUrlPresets?: ReadonlyArray<{ label: string; baseUrl: string }>;
+  defaults?: Pick<LLMProvider, 'baseUrl' | 'models' | 'modelConfigs'>;
 };
+
+const MINIMAX_BASE_URL_PRESETS = MINIMAX_PROVIDER_ENDPOINTS.map((endpoint) => ({
+  label: `${endpoint.region === 'global_en' ? 'Global' : 'China'} (${
+    endpoint.apiStyle === 'chatCompletions' ? 'Chat Completions' : 'Messages'
+  })`,
+  baseUrl: endpoint.baseUrl,
+}));
 
 export const LLM_PROVIDERS: readonly LLMProviderOption[] = [
   {
@@ -76,6 +91,19 @@ export const LLM_PROVIDERS: readonly LLMProviderOption[] = [
     modelsPlaceholder: 'deepseek-chat,deepseek-reasoner',
     Icon: LLM_PROVIDER_ICONS[LLMProviderType.DEEPSEEK],
     hideInProviderSelect: true,
+  },
+  {
+    value: LLMProviderType.MINIMAX,
+    label: 'MiniMax',
+    baseUrlPlaceholder: MINIMAX_PROVIDER_ENDPOINTS[0].baseUrl,
+    modelsPlaceholder: MINIMAX_MODEL_IDS.join(','),
+    Icon: LLM_PROVIDER_ICONS[LLMProviderType.MINIMAX],
+    baseUrlPresets: MINIMAX_BASE_URL_PRESETS,
+    defaults: {
+      baseUrl: MINIMAX_PROVIDER_ENDPOINTS[0].baseUrl,
+      models: MINIMAX_MODEL_IDS.join(','),
+      modelConfigs: MINIMAX_DEFAULT_MODEL_CONFIGS,
+    },
   },
   {
     value: LLMProviderType.OPENAI,

--- a/packages/openapi/src/admin/setting/update.spec.ts
+++ b/packages/openapi/src/admin/setting/update.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { llmProviderSchema, LLMProviderType, modelKeySchema } from './update';
+import {
+  isMiniMaxMessagesEndpoint,
+  llmProviderSchema,
+  LLMProviderType,
+  MINIMAX_DEFAULT_MODEL_CONFIGS,
+  MINIMAX_MODEL_IDS,
+  MINIMAX_PROVIDER_ENDPOINTS,
+  modelKeySchema,
+} from './update';
 import { gatewayApiModelRawSchema, getImageModelTagsFromAbility } from './index';
 
 const IMAGE_GENERATION_TAG = 'image-generation';
@@ -59,6 +67,70 @@ describe('llmProviderSchema', () => {
       models: 'gpt-4o,gemini-1.0-pro-001@vertex',
     });
     expect(result.success).toBe(false);
+  });
+
+  it('accepts the MiniMax provider preset', () => {
+    expect(
+      llmProviderSchema.safeParse({
+        type: LLMProviderType.MINIMAX,
+        name: 'minimax',
+        baseUrl: MINIMAX_PROVIDER_ENDPOINTS[0].baseUrl,
+        models: MINIMAX_MODEL_IDS.join(','),
+        modelConfigs: MINIMAX_DEFAULT_MODEL_CONFIGS,
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe('MiniMax provider preset', () => {
+  it('contains regional chat and messages endpoints', () => {
+    expect(MINIMAX_PROVIDER_ENDPOINTS).toEqual([
+      {
+        region: 'global_en',
+        apiStyle: 'chatCompletions',
+        baseUrl: 'https://api.minimax.io/v1',
+      },
+      {
+        region: 'cn_zh',
+        apiStyle: 'chatCompletions',
+        baseUrl: 'https://api.minimaxi.com/v1',
+      },
+      {
+        region: 'global_en',
+        apiStyle: 'messages',
+        baseUrl: 'https://api.minimax.io/anthropic',
+      },
+      {
+        region: 'cn_zh',
+        apiStyle: 'messages',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+      },
+    ]);
+    expect(isMiniMaxMessagesEndpoint('https://api.minimax.io/anthropic/')).toBe(true);
+    expect(isMiniMaxMessagesEndpoint('https://api.minimax.io/v1')).toBe(false);
+  });
+
+  it('contains the current text model metadata', () => {
+    expect(MINIMAX_MODEL_IDS).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+    expect(MINIMAX_DEFAULT_MODEL_CONFIGS['MiniMax-M3']).toMatchObject({
+      contextWindow: 1_000_000,
+      pricing: {
+        input: '0.0000006',
+        output: '0.0000024',
+        inputCacheRead: '0.00000012',
+      },
+      ability: { image: true, reasoning: true },
+    });
+    expect(MINIMAX_DEFAULT_MODEL_CONFIGS['MiniMax-M2.7']).toMatchObject({
+      contextWindow: 204_800,
+      pricing: {
+        input: '0.0000003',
+        output: '0.0000012',
+        inputCacheRead: '0.00000006',
+        inputCacheWrite: '0.000000375',
+      },
+      ability: { reasoning: true },
+    });
   });
 });
 

--- a/packages/openapi/src/admin/setting/update.ts
+++ b/packages/openapi/src/admin/setting/update.ts
@@ -29,6 +29,7 @@ export enum LLMProviderType {
   COHERE = 'cohere',
   MISTRAL = 'mistral',
   DEEPSEEK = 'deepseek',
+  MINIMAX = 'minimax',
   QWEN = 'qwen',
   ZHIPU = 'zhipu',
   LINGYIWANWU = 'lingyiwanwu',
@@ -83,6 +84,67 @@ export const modelConfigSchema = z.object({
 });
 
 export type IModelConfig = z.infer<typeof modelConfigSchema>;
+
+export const MINIMAX_MODEL_IDS = ['MiniMax-M3', 'MiniMax-M2.7'] as const;
+
+export const MINIMAX_PROVIDER_ENDPOINTS = [
+  {
+    region: 'global_en',
+    apiStyle: 'chatCompletions',
+    baseUrl: 'https://api.minimax.io/v1',
+  },
+  {
+    region: 'cn_zh',
+    apiStyle: 'chatCompletions',
+    baseUrl: 'https://api.minimaxi.com/v1',
+  },
+  {
+    region: 'global_en',
+    apiStyle: 'messages',
+    baseUrl: 'https://api.minimax.io/anthropic',
+  },
+  {
+    region: 'cn_zh',
+    apiStyle: 'messages',
+    baseUrl: 'https://api.minimaxi.com/anthropic',
+  },
+] as const;
+
+export const MINIMAX_DEFAULT_MODEL_CONFIGS = {
+  'MiniMax-M3': {
+    pricing: {
+      input: '0.0000006',
+      output: '0.0000024',
+      inputCacheRead: '0.00000012',
+    },
+    ability: { image: true, reasoning: true },
+    ownedBy: 'minimax',
+    modelType: 'language',
+    tags: ['reasoning', 'vision', 'video-input'],
+    contextWindow: 1_000_000,
+  },
+  'MiniMax-M2.7': {
+    pricing: {
+      input: '0.0000003',
+      output: '0.0000012',
+      inputCacheRead: '0.00000006',
+      inputCacheWrite: '0.000000375',
+    },
+    ability: { reasoning: true },
+    ownedBy: 'minimax',
+    modelType: 'language',
+    tags: ['reasoning'],
+    contextWindow: 204_800,
+  },
+} satisfies Record<(typeof MINIMAX_MODEL_IDS)[number], IModelConfig>;
+
+export const isMiniMaxMessagesEndpoint = (baseUrl: string): boolean => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+  return MINIMAX_PROVIDER_ENDPOINTS.some(
+    (endpoint) =>
+      endpoint.apiStyle === 'messages' && endpoint.baseUrl.replace(/\/+$/, '') === normalizedBaseUrl
+  );
+};
 
 export const llmProviderSchema = z.object({
   type: z.enum(LLMProviderType),


### PR DESCRIPTION
Reason: MiniMax requires a first-class provider configuration with current text models and regional endpoint presets.

## Changes

- Register MiniMax in the direct LLM provider schema and backend adapter map.
- Add global and China endpoint presets for chat completions and messages APIs.
- Preload MiniMax-M3 and MiniMax-M2.7 with current context, pricing, and capability metadata.
- Add focused schema, adapter routing, and admin form coverage.

## Checks

- `pnpm --filter @teable/openapi exec vitest run src/admin/setting/update.spec.ts --silent=true`
- `pnpm --filter @teable/backend exec vitest run src/features/ai/util.spec.ts --silent=true`
- `pnpm --filter @teable/app exec vitest run src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.spec.tsx --silent=true`
- `pnpm --filter @teable/openapi typecheck`
- `pnpm --filter @teable/app typecheck`
- `pnpm --filter @teable/openapi exec eslint src/admin/setting/update.ts src/admin/setting/update.spec.ts`
- `pnpm --filter @teable/backend exec eslint src/features/ai/util.ts src/features/ai/util.spec.ts`
- `pnpm --filter @teable/app exec eslint src/features/app/blocks/admin/setting/components/ai-config/constant.ts src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.tsx src/features/app/blocks/admin/setting/components/ai-config/LlmProviderForm.spec.tsx`
- `git diff --check`
