### PR TITLE
fix(web): size the app to the dynamic viewport on mobile Safari

### DIFF
--- a/apps/nextjs-app/src/components/layout/MainLayout.tsx
+++ b/apps/nextjs-app/src/components/layout/MainLayout.tsx
@@ -3,7 +3,7 @@ import type { FC, ReactNode } from 'react';
 export const MainLayout: FC<{ children: ReactNode }> = (props) => {
   const { children } = props;
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-dvh flex-col">
       <main>{children}</main>
     </div>
   );

--- a/apps/nextjs-app/src/features/app/blocks/share/base/BaseShareAuthPage.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/share/base/BaseShareAuthPage.tsx
@@ -47,7 +47,7 @@ export const BaseShareAuthPage = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+    <div className="flex min-h-dvh items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-8">
         <h2 className="text-center text-3xl font-extrabold">{t('share:auth.title')}</h2>
         <form className="relative space-y-6" onSubmit={onSubmit}>

--- a/apps/nextjs-app/src/features/app/blocks/share/view/AuthPage.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/share/view/AuthPage.tsx
@@ -46,7 +46,7 @@ export const AuthPage = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+    <div className="flex min-h-dvh items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-8">
         <h2 className="text-center text-3xl font-extrabold">{t('share:auth.title')}</h2>
         <form className="relative space-y-6" onSubmit={onSubmit}>

--- a/apps/nextjs-app/src/features/app/layouts/SettingLayout.tsx
+++ b/apps/nextjs-app/src/features/app/layouts/SettingLayout.tsx
@@ -33,7 +33,7 @@ export const SettingLayout: React.FC<{
     <AppLayout>
       <AppProvider lang={i18n.language} locale={sdkLocale} dehydratedState={dehydratedState}>
         <SessionProvider user={user}>
-          <div id="portal" className="relative flex h-screen w-full items-start">
+          <div id="portal" className="relative flex h-dvh w-full items-start">
             <Sidebar
               headerLeft={<SidebarHeaderLeft title={t('common:settings.title')} onBack={onBack} />}
             >

--- a/apps/nextjs-app/src/features/app/layouts/SpaceLayout.tsx
+++ b/apps/nextjs-app/src/features/app/layouts/SpaceLayout.tsx
@@ -28,7 +28,7 @@ export const SpaceLayout: React.FC<{
         <SessionProvider user={user}>
           <NotificationProvider>
             <LicenseExpiryBanner />
-            <div id="portal" className="relative flex h-screen w-full items-start">
+            <div id="portal" className="relative flex h-dvh w-full items-start">
               <Sidebar headerLeft={<SidebarHeaderLeft />}>
                 <Fragment>
                   <div className="flex flex-1 flex-col gap-2 divide-y divide-solid overflow-hidden">

--- a/apps/nextjs-app/src/features/app/waitlist/WaitlistPage.tsx
+++ b/apps/nextjs-app/src/features/app/waitlist/WaitlistPage.tsx
@@ -57,7 +57,7 @@ const WaitlistPageInner = () => {
 
   if (isSubmitted) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+      <div className="flex min-h-dvh items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
             <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-green-100">
@@ -91,7 +91,7 @@ const WaitlistPageInner = () => {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
       <div className="mb-16 text-center">
         <h1 className="mb-4 text-4xl font-bold text-gray-900">{t('waitlist.joinTitle')}</h1>
         <h2 className="text-xl  text-gray-900">{t('waitlist.joinDesc')}</h2>

--- a/apps/nextjs-app/src/features/auth/components/LayoutMain.tsx
+++ b/apps/nextjs-app/src/features/auth/components/LayoutMain.tsx
@@ -8,7 +8,7 @@ interface ILayoutMainProps {
 export const LayoutMain = (props: ILayoutMainProps) => {
   const { children } = props;
   return (
-    <div className="fixed flex h-screen w-full flex-col  justify-center gap-8 overflow-y-auto px-8 py-6 sm:px-6 lg:px-8">
+    <div className="fixed flex h-dvh w-full flex-col  justify-center gap-8 overflow-y-auto px-8 py-6 sm:px-6 lg:px-8">
       <Card className="mx-auto flex w-full max-w-md flex-col p-9">{children}</Card>
       <TeableFooter enableClick />
     </div>

--- a/apps/nextjs-app/src/features/auth/pages/LoginPage.tsx
+++ b/apps/nextjs-app/src/features/auth/pages/LoginPage.tsx
@@ -85,7 +85,7 @@ export const LoginPage = (props: { children?: React.ReactNode | React.ReactNode[
 
   return (
     <ScrollArea className="h-screen">
-      <div className="flex min-h-screen">
+      <div className="flex min-h-dvh">
         <NextSeo title={signType === 'signin' ? t('auth:page.signin') : t('auth:page.signup')} />
         <DescContent />
         <div className="relative flex flex-1 shrink-0 flex-col items-center justify-start sm:justify-center">

--- a/apps/nextjs-app/src/styles/global.css
+++ b/apps/nextjs-app/src/styles/global.css
@@ -29,18 +29,18 @@ body[data-teable-top-banner='visible'] #portal {
   margin-top: var(--teable-top-banner-height);
 }
 
-body[data-teable-top-banner='visible'] #portal.h-screen,
-body[data-teable-top-banner='visible'] #portal .h-screen {
-  height: calc(100vh - var(--teable-top-banner-height));
+body[data-teable-top-banner='visible'] #portal.h-dvh,
+body[data-teable-top-banner='visible'] #portal .h-dvh {
+  height: calc(100dvh - var(--teable-top-banner-height));
 }
 
-body[data-teable-top-banner='visible'] #portal.min-h-screen,
-body[data-teable-top-banner='visible'] #portal .min-h-screen {
-  min-height: calc(100vh - var(--teable-top-banner-height));
+body[data-teable-top-banner='visible'] #portal.min-h-dvh,
+body[data-teable-top-banner='visible'] #portal .min-h-dvh {
+  min-height: calc(100dvh - var(--teable-top-banner-height));
 }
 
 .select-field-type [cmdk-list] {
-  max-height: min(600px, calc(100vh - 450px));
+  max-height: min(600px, calc(100dvh - 450px));
 }
 
 .height-preserving-container:empty {


### PR DESCRIPTION
Closes #3642

## Problem
On mobile Safari (iPad, and iPhone) the URL bar / toolbar are part of the viewport that `100vh` resolves against, so containers sized with `h-screen` / `min-h-screen` end up taller than the actually visible area. The app then scrolls as a document: with the toolbar visible the sidebar footer (user avatar + notifications) sits below the fold, and scrolling the browser chrome away pushes the top bar out of view instead.

## Fix
Use the dynamic viewport unit (`100dvh` — Tailwind `h-dvh` / `min-h-dvh`) for the layout and full-height page containers, so their height tracks the *visible* viewport as the browser chrome animates:

- `components/layout/MainLayout.tsx` — the app shell
- `features/app/layouts/SpaceLayout.tsx`, `SettingLayout.tsx` — the `#portal` layouts
- `features/auth/components/LayoutMain.tsx`, `features/auth/pages/LoginPage.tsx`, `features/app/waitlist/WaitlistPage.tsx`, `features/app/blocks/share/...` — full-height auth / waitlist / share pages
- `styles/global.css` — the top-banner compensation rules are keyed on `.h-screen` / `.min-h-screen` and subtract `--teable-top-banner-height`; they are updated to the new class names and unit so the banner offset keeps working

## Why `dvh`
`dvh` is supported by iOS Safari 15.4+, Chrome 108+ and Firefox 101+ (≈97% global baseline), and this repo already uses `dvh` units elsewhere (`packages/sdk`, `packages/ui-lib`), so this follows existing practice rather than introducing a new convention.

## Notes
- Desktop behaviour is unchanged — `dvh` equals `vh` when there is no dynamic browser chrome.
- Scoped to viewport-sized layout containers; `h-screen` inside individual components is left as-is.
- I could not run the visual check on an iPad from this environment — verified by diff inspection against the reported symptoms. Happy to adjust if you prefer to keep `vh` as a fallback declaration.